### PR TITLE
NFT aggregate refactoring

### DIFF
--- a/domain/src/Nft/Actions/IncreaseNftCostBasis.php
+++ b/domain/src/Nft/Actions/IncreaseNftCostBasis.php
@@ -9,7 +9,7 @@ final class IncreaseNftCostBasis
 {
     public function __construct(
         public readonly NftId $nftId,
-        public readonly FiatAmount $extraCostBasis,
+        public readonly FiatAmount $costBasisIncrease,
     ) {
     }
 }

--- a/domain/src/Nft/Events/NftCostBasisIncreased.php
+++ b/domain/src/Nft/Events/NftCostBasisIncreased.php
@@ -9,9 +9,7 @@ final class NftCostBasisIncreased
 {
     public function __construct(
         public readonly NftId $nftId,
-        public readonly FiatAmount $previousCostBasis,
-        public readonly FiatAmount $extraCostBasis,
-        public readonly FiatAmount $newCostBasis,
+        public readonly FiatAmount $costBasisIncrease,
     ) {
     }
 }

--- a/domain/src/Nft/Nft.php
+++ b/domain/src/Nft/Nft.php
@@ -24,10 +24,10 @@ final class Nft implements AggregateRoot
     public function acquire(AcquireNft $action): void
     {
         if (! is_null($this->costBasis)) {
-            throw NftException::alreadyAcquired($this->aggregateRootId);
+            throw NftException::alreadyAcquired($action->nftId);
         }
 
-        $this->recordThat(new NftAcquired(nftId: $this->aggregateRootId, costBasis: $action->costBasis));
+        $this->recordThat(new NftAcquired(nftId: $action->nftId, costBasis: $action->costBasis));
     }
 
     public function applyNftAcquired(NftAcquired $event): void
@@ -39,44 +39,44 @@ final class Nft implements AggregateRoot
     public function increaseCostBasis(IncreaseNftCostBasis $action): void
     {
         if (is_null($this->costBasis)) {
-            throw NftException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId);
+            throw NftException::cannotIncreaseCostBasisBeforeAcquisition($action->nftId);
         }
 
-        if ($this->costBasis->currency !== $action->extraCostBasis->currency) {
+        if ($this->costBasis->currency !== $action->costBasisIncrease->currency) {
             throw NftException::cannotIncreaseCostBasisFromDifferentCurrency(
-                nftId: $this->aggregateRootId,
+                nftId: $action->nftId,
                 from: $this->costBasis->currency,
-                to: $action->extraCostBasis->currency,
+                to: $action->costBasisIncrease->currency,
             );
         }
 
-        $newCostBasis = new FiatAmount(
-            amount: Math::add($this->costBasis->amount, $action->extraCostBasis->amount),
-            currency: $this->costBasis->currency,
-        );
-
         $this->recordThat(new NftCostBasisIncreased(
-            nftId: $this->aggregateRootId,
-            previousCostBasis: $this->costBasis,
-            extraCostBasis: $action->extraCostBasis,
-            newCostBasis: $newCostBasis,
+            nftId: $action->nftId,
+            costBasisIncrease: $action->costBasisIncrease,
         ));
     }
 
     public function applyNftCostBasisIncreased(NftCostBasisIncreased $event): void
     {
-        $this->costBasis = $event->newCostBasis;
+        assert(! is_null($this->costBasis));
+
+        $newCostBasis = new FiatAmount(
+            amount: Math::add($this->costBasis->amount, $event->costBasisIncrease->amount),
+            currency: $this->costBasis->currency,
+        );
+
+        $this->costBasis = $newCostBasis;
     }
 
     /** @throws NftException */
     public function disposeOf(DisposeOfNft $action): void
     {
         if (is_null($this->costBasis)) {
-            throw NftException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId);
+            throw NftException::cannotDisposeOfBeforeAcquisition($action->nftId);
         }
 
         $this->recordThat(new NftDisposedOf(
-            nftId: $this->aggregateRootId,
+            nftId: $action->nftId,
             costBasis: $this->costBasis,
             disposalProceeds: $action->disposalProceeds
         ));

--- a/domain/tests/Nft/NftTest.php
+++ b/domain/tests/Nft/NftTest.php
@@ -40,12 +40,10 @@ it('cannot acquire the same NFT more than once', function () {
 
 it('can increase the cost basis of a NFT', function () {
     $nftAcquired = new NftAcquired(nftId: $this->nftId, costBasis: new FiatAmount('100', Currency::GBP));
-    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, extraCostBasis: new FiatAmount('50', Currency::GBP));
+    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, costBasisIncrease: new FiatAmount('50', Currency::GBP));
     $nftCostBasisIncreased = new NftCostBasisIncreased(
-        nftId: $this->nftId,
-        previousCostBasis: $nftAcquired->costBasis,
-        extraCostBasis: $increaseNftCostBasis->extraCostBasis,
-        newCostBasis: new FiatAmount('150', Currency::GBP),
+        nftId: $increaseNftCostBasis->nftId,
+        costBasisIncrease: $increaseNftCostBasis->costBasisIncrease,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -55,8 +53,8 @@ it('can increase the cost basis of a NFT', function () {
 });
 
 it('cannot increase the cost basis of a NFT that has not been acquired', function () {
-    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, extraCostBasis: new FiatAmount('100', Currency::GBP));
-    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisBeforeAcquisition($this->nftId);
+    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, costBasisIncrease: new FiatAmount('100', Currency::GBP));
+    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisBeforeAcquisition($increaseNftCostBasis->nftId);
 
     /** @var AggregateRootTestCase $this */
     $this->when($increaseNftCostBasis)
@@ -65,9 +63,9 @@ it('cannot increase the cost basis of a NFT that has not been acquired', functio
 
 it('cannot increase the cost basis of a NFT because the currency is different', function () {
     $nftAcquired = new NftAcquired(nftId: $this->nftId, costBasis: new FiatAmount('100', Currency::GBP));
-    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, extraCostBasis: new FiatAmount('100', Currency::EUR));
+    $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, costBasisIncrease: new FiatAmount('100', Currency::EUR));
     $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisFromDifferentCurrency(
-        nftId: $this->nftId,
+        nftId: $increaseNftCostBasis->nftId,
         from: Currency::GBP,
         to: Currency::EUR,
     );
@@ -82,7 +80,7 @@ it('can dispose of a NFT', function () {
     $nftAcquired = new NftAcquired(nftId: $this->nftId, costBasis: new FiatAmount('100', Currency::GBP));
     $disposeOfNft = new DisposeOfNft(nftId: $this->nftId, disposalProceeds: new FiatAmount('150', Currency::GBP));
     $nftDisposedOf = new NftDisposedOf(
-        nftId: $this->nftId,
+        nftId: $disposeOfNft->nftId,
         costBasis: $nftAcquired->costBasis,
         disposalProceeds: $disposeOfNft->disposalProceeds,
     );
@@ -95,7 +93,7 @@ it('can dispose of a NFT', function () {
 
 it('cannot dispose of a NFT that has not been acquired', function () {
     $disposeOfNft = new DisposeOfNft(nftId: $this->nftId, disposalProceeds: new FiatAmount('100', Currency::GBP));
-    $cannotDisposeOf = NftException::cannotDisposeOfBeforeAcquisition($this->nftId);
+    $cannotDisposeOf = NftException::cannotDisposeOfBeforeAcquisition($disposeOfNft->nftId);
 
     /** @var AggregateRootTestCase $this */
     $this->when($disposeOfNft)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,8 +4,3 @@ parameters:
 	paths:
 		- app
 		- domain/src
-
-	ignoreErrors:
-		-
-			message: "#^.+EventSauce\\\\EventSourcing\\\\AggregateRootId given\\.$#"
-			path: domain/src


### PR DESCRIPTION
## Description

This PR refactors the NFT aggregate to make it clearer.

## Explanation

Some properties were renamed for clarity, and events do not include calculations anymore – those are done in `applyXXX` methods instead. This is to avoid cluttered events and is consistent with the upcoming Section 104 pool aggregate.