### PR TITLE
Tax year aggregate

### DIFF
--- a/domain/src/Nft/Exceptions/NftException.php
+++ b/domain/src/Nft/Exceptions/NftException.php
@@ -28,7 +28,7 @@ final class NftException extends RuntimeException
         ));
     }
 
-    public static function cannotIncreaseCostBasisFromDifferentFiatCurrency(
+    public static function cannotIncreaseCostBasisFromDifferentCurrency(
         NftId $nftId,
         FiatCurrency $from,
         FiatCurrency $to

--- a/domain/src/Nft/Nft.php
+++ b/domain/src/Nft/Nft.php
@@ -44,7 +44,7 @@ final class Nft implements AggregateRoot
         }
 
         if ($this->costBasis->currency !== $action->costBasisIncrease->currency) {
-            throw NftException::cannotIncreaseCostBasisFromDifferentFiatCurrency(
+            throw NftException::cannotIncreaseCostBasisFromDifferentCurrency(
                 nftId: $action->nftId,
                 from: $this->costBasis->currency,
                 to: $action->costBasisIncrease->currency,

--- a/domain/src/Nft/Repositories/NftRepository.php
+++ b/domain/src/Nft/Repositories/NftRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Domain\Repositories;
+namespace Domain\Nft\Repositories;
 
 use Domain\Nft\Nft;
 use EventSauce\EventSourcing\ClassNameInflector;

--- a/domain/src/SharePooling/Exceptions/SharePoolingException.php
+++ b/domain/src/SharePooling/Exceptions/SharePoolingException.php
@@ -16,7 +16,7 @@ final class SharePoolingException extends RuntimeException
         parent::__construct($message);
     }
 
-    public static function cannotAcquireFromDifferentFiatCurrency(
+    public static function cannotAcquireFromDifferentCurrency(
         SharePoolingId $sharePoolingId,
         FiatCurrency $from,
         FiatCurrency $to
@@ -29,7 +29,7 @@ final class SharePoolingException extends RuntimeException
         ));
     }
 
-    public static function cannotDisposeOfFromDifferentFiatCurrency(
+    public static function cannotDisposeOfFromDifferentCurrency(
         SharePoolingId $sharePoolingId,
         FiatCurrency $from,
         FiatCurrency $to
@@ -48,7 +48,7 @@ final class SharePoolingException extends RuntimeException
         Quantity $availableQuantity
     ): self {
         return new self(sprintf(
-            'Tried to dispose of %s section 104 pool %s tokens but only %s are available',
+            'Trying to dispose of %s section 104 pool %s tokens but only %s are available',
             $disposalQuantity,
             $sharePoolingId->toString(),
             $availableQuantity,

--- a/domain/src/SharePooling/SharePooling.php
+++ b/domain/src/SharePooling/SharePooling.php
@@ -42,7 +42,7 @@ final class SharePooling implements AggregateRoot
     public function acquire(AcquireSharePoolingToken $action): void
     {
         if ($this->fiatCurrency && $this->fiatCurrency !== $action->costBasis->currency) {
-            throw SharePoolingException::cannotAcquireFromDifferentFiatCurrency(
+            throw SharePoolingException::cannotAcquireFromDifferentCurrency(
                 sharePoolingId: $action->sharePoolingId,
                 from: $this->fiatCurrency,
                 to: $action->costBasis->currency,
@@ -99,7 +99,7 @@ final class SharePooling implements AggregateRoot
     public function disposeOf(DisposeOfSharePoolingToken $action): void
     {
         if ($this->fiatCurrency && $this->fiatCurrency !== $action->proceeds->currency) {
-            throw SharePoolingException::cannotDisposeOfFromDifferentFiatCurrency(
+            throw SharePoolingException::cannotDisposeOfFromDifferentCurrency(
                 sharePoolingId: $action->sharePoolingId,
                 from: $this->fiatCurrency,
                 to: $action->proceeds->currency,

--- a/domain/src/TaxYear/Actions/RecordCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalGain.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RecordCapitalGain
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Actions/RecordCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalLoss.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RecordCapitalLoss
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Actions/RecordIncome.php
+++ b/domain/src/TaxYear/Actions/RecordIncome.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RecordIncome
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
+++ b/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RecordNonAttributableAllowableCost
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Actions/RevertCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalGain.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RevertCapitalGain
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Actions/RevertCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalLoss.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class RevertCapitalLoss
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/CapitalGainRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalGainRecorded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class CapitalGainRecorded
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/CapitalGainReverted.php
+++ b/domain/src/TaxYear/Events/CapitalGainReverted.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class CapitalGainReverted
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/CapitalLossRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalLossRecorded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class CapitalLossRecorded
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/CapitalLossReverted.php
+++ b/domain/src/TaxYear/Events/CapitalLossReverted.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class CapitalLossReverted
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/IncomeRecorded.php
+++ b/domain/src/TaxYear/Events/IncomeRecorded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class IncomeRecorded
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
+++ b/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+final class NonAttributableAllowableCostRecorded
+{
+    public function __construct(
+        public readonly TaxYearId $taxYearId,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/TaxYear/Exceptions/TaxYearException.php
@@ -82,4 +82,17 @@ final class TaxYearException extends RuntimeException
             $to->name(),
         ));
     }
+
+    public static function cannotRecordIncomeFromDifferentCurrency(
+        TaxYearId $taxYearId,
+        FiatCurrency $from,
+        FiatCurrency $to
+    ): self {
+        return new self(sprintf(
+            'Cannot record some income for tax year %s because the currencies don\'t match (from %s to %s)',
+            $taxYearId->toString(),
+            $from->name(),
+            $to->name(),
+        ));
+    }
 }

--- a/domain/src/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/TaxYear/Exceptions/TaxYearException.php
@@ -95,4 +95,17 @@ final class TaxYearException extends RuntimeException
             $to->name(),
         ));
     }
+
+    public static function cannotRecordNonAttributableAllowableCostFromDifferentCurrency(
+        TaxYearId $taxYearId,
+        FiatCurrency $from,
+        FiatCurrency $to
+    ): self {
+        return new self(sprintf(
+            'Cannot record a non-attributable allowable cost for tax year %s because the currencies don\'t match (from %s to %s)',
+            $taxYearId->toString(),
+            $from->name(),
+            $to->name(),
+        ));
+    }
 }

--- a/domain/src/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/TaxYear/Exceptions/TaxYearException.php
@@ -6,7 +6,6 @@ namespace Domain\TaxYear\Exceptions;
 
 use Domain\Enums\FiatCurrency;
 use Domain\TaxYear\TaxYearId;
-use Domain\ValueObjects\FiatAmount;
 use RuntimeException;
 
 final class TaxYearException extends RuntimeException

--- a/domain/src/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/TaxYear/Exceptions/TaxYearException.php
@@ -32,7 +32,7 @@ final class TaxYearException extends RuntimeException
     public static function cannotRevertCapitalGainBeforeCapitalGainIsRecorded(TaxYearId $taxYearId): self
     {
         return new self(sprintf(
-            'Cannot revert capital gain for tax year %s because no capital gain was recorded yet',
+            'Cannot revert capital gain for tax year %s because no capital gain or loss was recorded yet',
             $taxYearId->toString(),
         ));
     }
@@ -50,16 +50,37 @@ final class TaxYearException extends RuntimeException
         ));
     }
 
-    public static function cannotRevertCapitalGainBecauseAmountIsTooHigh(
+    public static function cannotRecordCapitalLossForDifferentCurrency(
         TaxYearId $taxYearId,
-        FiatAmount $amountToRevert,
-        FiatAmount $availableAmount
+        FiatCurrency $from,
+        FiatCurrency $to
     ): self {
         return new self(sprintf(
-            'Trying to revert capital gain of %s for tax year %s but only %s is available',
-            $amountToRevert,
+            'Cannot record capital loss for tax year %s because the currencies don\'t match (from %s to %s)',
             $taxYearId->toString(),
-            $availableAmount,
+            $from->name(),
+            $to->name(),
+        ));
+    }
+
+    public static function cannotRevertCapitalLossBeforeCapitalLossIsRecorded(TaxYearId $taxYearId): self
+    {
+        return new self(sprintf(
+            'Cannot revert capital loss for tax year %s because no capital gain or loss was recorded yet',
+            $taxYearId->toString(),
+        ));
+    }
+
+    public static function cannotRevertCapitalLossFromDifferentCurrency(
+        TaxYearId $taxYearId,
+        FiatCurrency $from,
+        FiatCurrency $to
+    ): self {
+        return new self(sprintf(
+            'Cannot revert capital loss for tax year %s because the currencies don\'t match (from %s to %s)',
+            $taxYearId->toString(),
+            $from->name(),
+            $to->name(),
         ));
     }
 }

--- a/domain/src/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/TaxYear/Exceptions/TaxYearException.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Exceptions;
+
+use Domain\Enums\FiatCurrency;
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+use RuntimeException;
+
+final class TaxYearException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function cannotRecordCapitalGainForDifferentCurrency(
+        TaxYearId $taxYearId,
+        FiatCurrency $from,
+        FiatCurrency $to
+    ): self {
+        return new self(sprintf(
+            'Cannot record capital gain for tax year %s because the currencies don\'t match (from %s to %s)',
+            $taxYearId->toString(),
+            $from->name(),
+            $to->name(),
+        ));
+    }
+
+    public static function cannotRevertCapitalGainBeforeCapitalGainIsRecorded(TaxYearId $taxYearId): self
+    {
+        return new self(sprintf(
+            'Cannot revert capital gain for tax year %s because no capital gain was recorded yet',
+            $taxYearId->toString(),
+        ));
+    }
+
+    public static function cannotRevertCapitalGainFromDifferentCurrency(
+        TaxYearId $taxYearId,
+        FiatCurrency $from,
+        FiatCurrency $to
+    ): self {
+        return new self(sprintf(
+            'Cannot revert capital gain for tax year %s because the currencies don\'t match (from %s to %s)',
+            $taxYearId->toString(),
+            $from->name(),
+            $to->name(),
+        ));
+    }
+
+    public static function cannotRevertCapitalGainBecauseAmountIsTooHigh(
+        TaxYearId $taxYearId,
+        FiatAmount $amountToRevert,
+        FiatAmount $availableAmount
+    ): self {
+        return new self(sprintf(
+            'Trying to revert capital gain of %s for tax year %s but only %s is available',
+            $amountToRevert,
+            $taxYearId->toString(),
+            $availableAmount,
+        ));
+    }
+}

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear;
+
+use Domain\TaxYear\Actions\RecordCapitalGain;
+use Domain\TaxYear\Actions\RevertCapitalGain;
+use Domain\TaxYear\Events\CapitalGainRecorded;
+use Domain\TaxYear\Events\CapitalGainReverted;
+use Domain\TaxYear\Exceptions\TaxYearException;
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\EventSourcing\AggregateRoot;
+use EventSauce\EventSourcing\AggregateRootBehaviour;
+
+final class TaxYear implements AggregateRoot
+{
+    use AggregateRootBehaviour;
+
+    private ?FiatAmount $capitalGain = null;
+
+    public function recordCapitalGain(RecordCapitalGain $action): void
+    {
+        if ($this->capitalGain && $this->capitalGain->currency !== $action->amount->currency) {
+            throw TaxYearException::cannotRecordCapitalGainForDifferentCurrency(
+                taxYearId: $action->taxYearId,
+                from: $this->capitalGain->currency,
+                to: $action->amount->currency,
+            );
+        }
+
+        $this->recordThat(new CapitalGainRecorded(taxYearId: $action->taxYearId, amount: $action->amount));
+    }
+
+    public function applyCapitalGainRecorded(CapitalGainRecorded $event): void
+    {
+        $this->capitalGain = $this->capitalGain?->plus($event->amount) ?? $event->amount;
+    }
+
+    public function revertCapitalGain(RevertCapitalGain $action): void
+    {
+        if (is_null($this->capitalGain)) {
+            throw TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(taxYearId: $action->taxYearId);
+        }
+
+        if ($this->capitalGain->currency !== $action->amount->currency) {
+            throw TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
+                taxYearId: $action->taxYearId,
+                from: $this->capitalGain->currency,
+                to: $action->amount->currency,
+            );
+        }
+
+        if ($this->capitalGain->isLessThan($action->amount)) {
+            throw TaxYearException::cannotRevertCapitalGainBecauseAmountIsTooHigh(
+                taxYearId: $action->taxYearId,
+                amountToRevert: $action->amount,
+                availableAmount: $this->capitalGain,
+            );
+        }
+
+        $this->recordThat(new CapitalGainReverted(taxYearId: $action->taxYearId, amount: $action->amount));
+    }
+
+    public function applyCapitalGainReverted(CapitalGainReverted $event): void
+    {
+        $this->capitalGain = $this->capitalGain->minus($event->amount);
+    }
+}

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -56,7 +56,7 @@ final class TaxYear implements AggregateRoot
             throw TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(taxYearId: $action->taxYearId);
         }
 
-        if ($this->currency !== $action->amount->currency) {
+        if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
                 taxYearId: $action->taxYearId,
                 from: $this->currency,
@@ -100,7 +100,7 @@ final class TaxYear implements AggregateRoot
             throw TaxYearException::cannotRevertCapitalLossBeforeCapitalLossIsRecorded(taxYearId: $action->taxYearId);
         }
 
-        if ($this->currency !== $action->amount->currency) {
+        if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRevertCapitalLossFromDifferentCurrency(
                 taxYearId: $action->taxYearId,
                 from: $this->currency,

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -60,6 +60,8 @@ final class TaxYear implements AggregateRoot
 
     public function applyCapitalGainReverted(CapitalGainReverted $event): void
     {
+        assert(! is_null($this->capitalGainOrLoss));
+
         $this->capitalGainOrLoss = $this->capitalGainOrLoss->minus($event->amount);
     }
 
@@ -101,6 +103,8 @@ final class TaxYear implements AggregateRoot
 
     public function applyCapitalLossReverted(CapitalLossReverted $event): void
     {
+        assert(! is_null($this->capitalGainOrLoss));
+
         $this->capitalGainOrLoss = $this->capitalGainOrLoss->plus($event->amount);
     }
 }

--- a/domain/src/TaxYear/TaxYearId.php
+++ b/domain/src/TaxYear/TaxYearId.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear;
+
+use Domain\AggregateRootId;
+
+final class TaxYearId extends AggregateRootId
+{
+}

--- a/domain/src/ValueObjects/FiatAmount.php
+++ b/domain/src/ValueObjects/FiatAmount.php
@@ -22,6 +22,31 @@ final class FiatAmount implements Stringable
         return new self('0', $this->currency);
     }
 
+    public function isEqualTo(FiatAmount | Quantity | string $amount): bool
+    {
+        return Math::eq($this->amount, $this->extractValue($amount));
+    }
+
+    public function isGreaterThan(FiatAmount | Quantity | string $amount): bool
+    {
+        return Math::gt($this->amount, $this->extractValue($amount));
+    }
+
+    public function isGreaterThanOrEqualTo(FiatAmount | Quantity | string $amount): bool
+    {
+        return Math::gte($this->amount, $this->extractValue($amount));
+    }
+
+    public function isLessThan(FiatAmount | Quantity | string $amount): bool
+    {
+        return Math::lt($this->amount, $this->extractValue($amount));
+    }
+
+    public function isLessThanOrEqualTo(FiatAmount | Quantity | string $amount): bool
+    {
+        return Math::lte($this->amount, $this->extractValue($amount));
+    }
+
     /** @throws FiatAmountException */
     public function plus(FiatAmount | Quantity | string $operand): FiatAmount
     {

--- a/domain/tests/Nft/NftTest.php
+++ b/domain/tests/Nft/NftTest.php
@@ -64,7 +64,7 @@ it('cannot increase the cost basis of a NFT that has not been acquired', functio
 it('cannot increase the cost basis of a NFT because the currency is different', function () {
     $nftAcquired = new NftAcquired(nftId: $this->nftId, costBasis: new FiatAmount('100', FiatCurrency::GBP));
     $increaseNftCostBasis = new IncreaseNftCostBasis(nftId: $this->nftId, costBasisIncrease: new FiatAmount('100', FiatCurrency::EUR));
-    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisFromDifferentFiatCurrency(
+    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisFromDifferentCurrency(
         nftId: $increaseNftCostBasis->nftId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,

--- a/domain/tests/SharePooling/SharePoolingTest.php
+++ b/domain/tests/SharePooling/SharePoolingTest.php
@@ -93,7 +93,7 @@ it('cannot acquire more of the same share pooling tokens because currencies don\
         costBasis: new FiatAmount('300', FiatCurrency::EUR),
     );
 
-    $cannotAcquireSharePoolingToken = SharePoolingException::cannotAcquireFromDifferentFiatCurrency(
+    $cannotAcquireSharePoolingToken = SharePoolingException::cannotAcquireFromDifferentCurrency(
         sharePoolingId: $this->sharePoolingId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
@@ -157,7 +157,7 @@ it('cannot dispose of some share pooling tokens because currencies don\'t match'
         proceeds: new FiatAmount('100', FiatCurrency::EUR),
     );
 
-    $cannotDisposeOfSharePoolingToken = SharePoolingException::cannotDisposeOfFromDifferentFiatCurrency(
+    $cannotDisposeOfSharePoolingToken = SharePoolingException::cannotDisposeOfFromDifferentCurrency(
         sharePoolingId: $this->sharePoolingId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,

--- a/domain/tests/TaxYear/TaxYearTest.php
+++ b/domain/tests/TaxYear/TaxYearTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use Domain\Enums\FiatCurrency;
+use Domain\TaxYear\Actions\RecordCapitalGain;
+use Domain\TaxYear\Actions\RevertCapitalGain;
+use Domain\TaxYear\Events\CapitalGainRecorded;
+use Domain\TaxYear\Events\CapitalGainReverted;
+use Domain\TaxYear\Exceptions\TaxYearException;
+use Domain\Tests\TaxYear\TaxYearTestCase;
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
+
+uses(TaxYearTestCase::class);
+
+beforeEach(function () {
+    $this->taxYearId = $this->aggregateRootId();
+});
+
+it('can record a capital gain', function () {
+    $recordCapitalGain = new RecordCapitalGain(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYearId: $recordCapitalGain->taxYearId,
+        amount: $recordCapitalGain->amount,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->when($recordCapitalGain)
+        ->then($capitalGainRecorded);
+});
+
+it('cannot record a capital gain because the currency is different', function () {
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $recordCapitalGain = new RecordCapitalGain(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
+    $cannotRecordCapitalGain = TaxYearException::cannotRecordCapitalGainForDifferentCurrency(
+        taxYearId: $recordCapitalGain->taxYearId,
+        from: FiatCurrency::GBP,
+        to: FiatCurrency::EUR,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->given($capitalGainRecorded)
+        ->when($recordCapitalGain)
+        ->expectToFail($cannotRecordCapitalGain);
+});
+
+it('can revert a capital gain', function () {
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYearId: $capitalGainRecorded->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalGainReverted = new CapitalGainReverted(
+        taxYearId: $capitalGainRecorded->taxYearId,
+        amount: $revertCapitalGain->amount,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->given($capitalGainRecorded)
+        ->when($revertCapitalGain)
+        ->then($capitalGainReverted);
+});
+
+it('cannot revert a capital gain before a capital gain was recorded', function () {
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
+    $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(
+        taxYearId: $revertCapitalGain->taxYearId,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->when($revertCapitalGain)
+        ->expectToFail($cannotRevertCapitalGain);
+});
+
+it('cannot revert a capital gain because the currency is different', function () {
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
+    $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
+        taxYearId: $revertCapitalGain->taxYearId,
+        from: FiatCurrency::GBP,
+        to: FiatCurrency::EUR,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->given($capitalGainRecorded)
+        ->when($revertCapitalGain)
+        ->expectToFail($cannotRevertCapitalGain);
+});
+
+it('cannot revert a capital gain because the amount is too high', function () {
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('50', FiatCurrency::GBP),
+    );
+
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYearId: $this->taxYearId,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainBecauseAmountIsTooHigh(
+        taxYearId: $revertCapitalGain->taxYearId,
+        amountToRevert: $revertCapitalGain->amount,
+        availableAmount: $capitalGainRecorded->amount,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->given($capitalGainRecorded)
+        ->when($revertCapitalGain)
+        ->expectToFail($cannotRevertCapitalGain);
+});

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -3,7 +3,9 @@
 namespace Domain\Tests\TaxYear;
 
 use Domain\TaxYear\Actions\RecordCapitalGain;
+use Domain\TaxYear\Actions\RecordCapitalLoss;
 use Domain\TaxYear\Actions\RevertCapitalGain;
+use Domain\TaxYear\Actions\RevertCapitalLoss;
 use Domain\TaxYear\TaxYear;
 use Domain\TaxYear\TaxYearId;
 use Domain\Tests\AggregateRootTestCase;
@@ -28,6 +30,8 @@ abstract class TaxYearTestCase extends AggregateRootTestCase
         match ($action::class) {
             RecordCapitalGain::class => $taxYear->recordCapitalGain($action),
             RevertCapitalGain::class => $taxYear->revertCapitalGain($action),
+            RecordCapitalLoss::class => $taxYear->recordCapitalLoss($action),
+            RevertCapitalLoss::class => $taxYear->revertCapitalLoss($action),
         };
 
         $this->repository->persist($taxYear);

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -4,6 +4,7 @@ namespace Domain\Tests\TaxYear;
 
 use Domain\TaxYear\Actions\RecordCapitalGain;
 use Domain\TaxYear\Actions\RecordCapitalLoss;
+use Domain\TaxYear\Actions\RecordIncome;
 use Domain\TaxYear\Actions\RevertCapitalGain;
 use Domain\TaxYear\Actions\RevertCapitalLoss;
 use Domain\TaxYear\TaxYear;
@@ -32,6 +33,7 @@ abstract class TaxYearTestCase extends AggregateRootTestCase
             RevertCapitalGain::class => $taxYear->revertCapitalGain($action),
             RecordCapitalLoss::class => $taxYear->recordCapitalLoss($action),
             RevertCapitalLoss::class => $taxYear->revertCapitalLoss($action),
+            RecordIncome::class => $taxYear->recordIncome($action),
         };
 
         $this->repository->persist($taxYear);

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Domain\Tests\TaxYear;
+
+use Domain\TaxYear\Actions\RecordCapitalGain;
+use Domain\TaxYear\Actions\RevertCapitalGain;
+use Domain\TaxYear\TaxYear;
+use Domain\TaxYear\TaxYearId;
+use Domain\Tests\AggregateRootTestCase;
+use EventSauce\EventSourcing\AggregateRootId;
+
+abstract class TaxYearTestCase extends AggregateRootTestCase
+{
+    protected function newAggregateRootId(): AggregateRootId
+    {
+        return TaxYearId::generate();
+    }
+
+    protected function aggregateRootClassName(): string
+    {
+        return TaxYear::class;
+    }
+
+    public function handle(object $action)
+    {
+        $taxYear = $this->repository->retrieve($action->taxYearId);
+
+        match ($action::class) {
+            RecordCapitalGain::class => $taxYear->recordCapitalGain($action),
+            RevertCapitalGain::class => $taxYear->revertCapitalGain($action),
+        };
+
+        $this->repository->persist($taxYear);
+    }
+}

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -5,6 +5,7 @@ namespace Domain\Tests\TaxYear;
 use Domain\TaxYear\Actions\RecordCapitalGain;
 use Domain\TaxYear\Actions\RecordCapitalLoss;
 use Domain\TaxYear\Actions\RecordIncome;
+use Domain\TaxYear\Actions\RecordNonAttributableAllowableCost;
 use Domain\TaxYear\Actions\RevertCapitalGain;
 use Domain\TaxYear\Actions\RevertCapitalLoss;
 use Domain\TaxYear\TaxYear;
@@ -34,6 +35,7 @@ abstract class TaxYearTestCase extends AggregateRootTestCase
             RecordCapitalLoss::class => $taxYear->recordCapitalLoss($action),
             RevertCapitalLoss::class => $taxYear->revertCapitalLoss($action),
             RecordIncome::class => $taxYear->recordIncome($action),
+            RecordNonAttributableAllowableCost::class => $taxYear->recordNonAttributableAllowableCost($action),
         };
 
         $this->repository->persist($taxYear);


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR adds the third and last aggregate root – `TaxYear`.

## Explanation <!-- deeper explanation to guide reviewers -->

The `TaxYear` aggregate is the one that will record the various forms of revenues, losses and costs, and compute them to return the amounts to be reported in a tax return.

Five actions can be performed on the aggregate:

* `RecordCapitalGain`;
* `RecordCapitalLoss`;
* `RecordIncome`;
* `RecordNonAttributableAllowableCost`;
* `RevertCapitalGain`; and
* `RevertCapitalLoss`.

The `Revert*` actions correspond to the possibility of reverting a disposal from the [`SharePooling` aggregate](https://github.com/osteel/dime/pull/4).

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
