### PR TITLE
Remove aggregate root ID from actions and events

### DIFF
--- a/domain/src/Nft/Actions/AcquireNft.php
+++ b/domain/src/Nft/Actions/AcquireNft.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Domain\Nft\Actions;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 
 final class AcquireNft
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $costBasis,
     ) {

--- a/domain/src/Nft/Actions/DisposeOfNft.php
+++ b/domain/src/Nft/Actions/DisposeOfNft.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Domain\Nft\Actions;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 
 final class DisposeOfNft
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $proceeds,
     ) {

--- a/domain/src/Nft/Actions/IncreaseNftCostBasis.php
+++ b/domain/src/Nft/Actions/IncreaseNftCostBasis.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Domain\Nft\Actions;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 
 final class IncreaseNftCostBasis
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $costBasisIncrease,
     ) {

--- a/domain/src/Nft/Events/NftAcquired.php
+++ b/domain/src/Nft/Events/NftAcquired.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Domain\Nft\Events;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class NftAcquired implements SerializablePayload
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $costBasis,
     ) {
@@ -22,7 +20,6 @@ final class NftAcquired implements SerializablePayload
     public function toPayload(): array
     {
         return [
-            'nft_id' => $this->nftId->id,
             'date' => $this->date->__toString(),
             'cost_basis' => $this->costBasis->toArray(),
         ];
@@ -32,7 +29,6 @@ final class NftAcquired implements SerializablePayload
     public static function fromPayload(array $payload): static
     {
         return new static(
-            NftId::fromString($payload['nft_id']), // @phpstan-ignore-line
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
             FiatAmount::fromArray($payload['cost_basis']), // @phpstan-ignore-line
         );

--- a/domain/src/Nft/Events/NftCostBasisIncreased.php
+++ b/domain/src/Nft/Events/NftCostBasisIncreased.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Domain\Nft\Events;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class NftCostBasisIncreased implements SerializablePayload
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $costBasisIncrease,
     ) {
@@ -22,7 +20,6 @@ final class NftCostBasisIncreased implements SerializablePayload
     public function toPayload(): array
     {
         return [
-            'nft_id' => $this->nftId->id,
             'date' => $this->date->__toString(),
             'cost_basis_increase' => $this->costBasisIncrease->toArray(),
         ];
@@ -32,7 +29,6 @@ final class NftCostBasisIncreased implements SerializablePayload
     public static function fromPayload(array $payload): static
     {
         return new static(
-            NftId::fromString($payload['nft_id']), // @phpstan-ignore-line
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
             FiatAmount::fromArray($payload['cost_basis_increase']), // @phpstan-ignore-line
         );

--- a/domain/src/Nft/Events/NftDisposedOf.php
+++ b/domain/src/Nft/Events/NftDisposedOf.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Domain\Nft\Events;
 
 use Brick\DateTime\LocalDate;
-use Domain\Nft\NftId;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class NftDisposedOf implements SerializablePayload
 {
     public function __construct(
-        public readonly NftId $nftId,
         public readonly LocalDate $date,
         public readonly FiatAmount $costBasis,
         public readonly FiatAmount $proceeds,
@@ -23,7 +21,6 @@ final class NftDisposedOf implements SerializablePayload
     public function toPayload(): array
     {
         return [
-            'nft_id' => $this->nftId->id,
             'date' => $this->date->__toString(),
             'cost_basis' => $this->costBasis->toArray(),
             'proceeds' => $this->proceeds->toArray(),
@@ -34,7 +31,6 @@ final class NftDisposedOf implements SerializablePayload
     public static function fromPayload(array $payload): static
     {
         return new static(
-            NftId::fromString($payload['nft_id']), // @phpstan-ignore-line
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
             FiatAmount::fromArray($payload['cost_basis']), // @phpstan-ignore-line
             FiatAmount::fromArray($payload['proceeds']), // @phpstan-ignore-line

--- a/domain/src/Nft/Nft.php
+++ b/domain/src/Nft/Nft.php
@@ -15,7 +15,7 @@ use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
 
-/** @property \Domain\Nft\NftId $aggregateRootId */
+/** @property NftId $aggregateRootId */
 final class Nft implements AggregateRoot
 {
     use AggregateRootBehaviour;

--- a/domain/src/Nft/Nft.php
+++ b/domain/src/Nft/Nft.php
@@ -15,6 +15,7 @@ use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
 
+/** @property \Domain\Nft\NftId $aggregateRootId */
 final class Nft implements AggregateRoot
 {
     use AggregateRootBehaviour;
@@ -25,11 +26,10 @@ final class Nft implements AggregateRoot
     public function acquire(AcquireNft $action): void
     {
         if (! is_null($this->costBasis)) {
-            throw NftException::alreadyAcquired($action->nftId);
+            throw NftException::alreadyAcquired($this->aggregateRootId);
         }
 
         $this->recordThat(new NftAcquired(
-            nftId: $action->nftId,
             date: $action->date,
             costBasis: $action->costBasis,
         ));
@@ -44,19 +44,18 @@ final class Nft implements AggregateRoot
     public function increaseCostBasis(IncreaseNftCostBasis $action): void
     {
         if (is_null($this->costBasis)) {
-            throw NftException::cannotIncreaseCostBasisBeforeAcquisition($action->nftId);
+            throw NftException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId);
         }
 
         if ($this->costBasis->currency !== $action->costBasisIncrease->currency) {
             throw NftException::cannotIncreaseCostBasisFromDifferentCurrency(
-                nftId: $action->nftId,
+                nftId: $this->aggregateRootId,
                 from: $this->costBasis->currency,
                 to: $action->costBasisIncrease->currency,
             );
         }
 
         $this->recordThat(new NftCostBasisIncreased(
-            nftId: $action->nftId,
             date: $action->date,
             costBasisIncrease: $action->costBasisIncrease,
         ));
@@ -73,11 +72,10 @@ final class Nft implements AggregateRoot
     public function disposeOf(DisposeOfNft $action): void
     {
         if (is_null($this->costBasis)) {
-            throw NftException::cannotDisposeOfBeforeAcquisition($action->nftId);
+            throw NftException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId);
         }
 
         $this->recordThat(new NftDisposedOf(
-            nftId: $action->nftId,
             date: $action->date,
             costBasis: $this->costBasis,
             proceeds: $action->proceeds

--- a/domain/src/Nft/Nft.php
+++ b/domain/src/Nft/Nft.php
@@ -14,6 +14,7 @@ use Domain\Nft\Exceptions\NftException;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
+use EventSauce\EventSourcing\AggregateRootId;
 
 /** @property NftId $aggregateRootId */
 final class Nft implements AggregateRoot
@@ -21,6 +22,11 @@ final class Nft implements AggregateRoot
     use AggregateRootBehaviour;
 
     private ?FiatAmount $costBasis = null;
+
+    private function __construct(AggregateRootId $aggregateRootId)
+    {
+        $this->aggregateRootId = NftId::fromString($aggregateRootId->toString());
+    }
 
     /** @throws NftException */
     public function acquire(AcquireNft $action): void

--- a/domain/src/Nft/Reactors/NftReactor.php
+++ b/domain/src/Nft/Reactors/NftReactor.php
@@ -24,13 +24,9 @@ final class NftReactor extends EventConsumer
         $taxYear = $this->taxYearRepository->get($taxYearId);
 
         if ($event->proceeds->isGreaterThan($event->costBasis)) {
-            $taxYear->recordCapitalGain(
-                new RecordCapitalGain(taxYearId: $taxYearId, amount: $event->proceeds->minus($event->costBasis)),
-            );
+            $taxYear->recordCapitalGain(new RecordCapitalGain(amount: $event->proceeds->minus($event->costBasis)));
         } else {
-            $taxYear->recordCapitalLoss(
-                new RecordCapitalLoss(taxYearId: $taxYearId, amount: $event->costBasis->minus($event->proceeds)),
-            );
+            $taxYear->recordCapitalLoss(new RecordCapitalLoss(amount: $event->costBasis->minus($event->proceeds)));
         }
 
         $this->taxYearRepository->save($taxYear);

--- a/domain/src/SharePooling/Actions/AcquireSharePoolingToken.php
+++ b/domain/src/SharePooling/Actions/AcquireSharePoolingToken.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Domain\SharePooling\Actions;
 
 use Brick\DateTime\LocalDate;
-use Domain\SharePooling\SharePoolingId;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 
 final class AcquireSharePoolingToken
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly LocalDate $date,
         public readonly Quantity $quantity,
         public readonly FiatAmount $costBasis,

--- a/domain/src/SharePooling/Actions/DisposeOfSharePoolingToken.php
+++ b/domain/src/SharePooling/Actions/DisposeOfSharePoolingToken.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Domain\SharePooling\Actions;
 
 use Brick\DateTime\LocalDate;
-use Domain\SharePooling\SharePoolingId;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 
 final class DisposeOfSharePoolingToken
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly LocalDate $date,
         public readonly Quantity $quantity,
         public readonly FiatAmount $proceeds,

--- a/domain/src/SharePooling/Actions/RevertSharePoolingTokenDisposal.php
+++ b/domain/src/SharePooling/Actions/RevertSharePoolingTokenDisposal.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\SharePooling\Actions;
 
-use Domain\SharePooling\SharePoolingId;
 use Domain\SharePooling\ValueObjects\SharePoolingTokenDisposal;
 
 final class RevertSharePoolingTokenDisposal
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly SharePoolingTokenDisposal $sharePoolingTokenDisposal,
     ) {
     }

--- a/domain/src/SharePooling/Events/SharePoolingTokenAcquired.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenAcquired.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\SharePooling\Events;
 
-use Domain\SharePooling\SharePoolingId;
 use Domain\SharePooling\ValueObjects\SharePoolingTokenAcquisition;
 
 final class SharePoolingTokenAcquired
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly SharePoolingTokenAcquisition $sharePoolingTokenAcquisition,
     ) {
     }

--- a/domain/src/SharePooling/Events/SharePoolingTokenDisposalReverted.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenDisposalReverted.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\SharePooling\Events;
 
-use Domain\SharePooling\SharePoolingId;
 use Domain\SharePooling\ValueObjects\SharePoolingTokenDisposal;
 
 final class SharePoolingTokenDisposalReverted
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly SharePoolingTokenDisposal $sharePoolingTokenDisposal,
     ) {
     }

--- a/domain/src/SharePooling/Events/SharePoolingTokenDisposedOf.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenDisposedOf.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\SharePooling\Events;
 
-use Domain\SharePooling\SharePoolingId;
 use Domain\SharePooling\ValueObjects\SharePoolingTokenDisposal;
 
 final class SharePoolingTokenDisposedOf
 {
     public function __construct(
-        public readonly SharePoolingId $sharePoolingId,
         public readonly SharePoolingTokenDisposal $sharePoolingTokenDisposal,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RecordCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalGain.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RecordCapitalGain
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RecordCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalLoss.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RecordCapitalLoss
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RecordIncome.php
+++ b/domain/src/TaxYear/Actions/RecordIncome.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RecordIncome
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
+++ b/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RecordNonAttributableAllowableCost
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RevertCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalGain.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RevertCapitalGain
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Actions/RevertCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalLoss.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class RevertCapitalLoss
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/CapitalGainRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalGainRecorded.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class CapitalGainRecorded
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/CapitalGainReverted.php
+++ b/domain/src/TaxYear/Events/CapitalGainReverted.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class CapitalGainReverted
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/CapitalLossRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalLossRecorded.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class CapitalLossRecorded
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/CapitalLossReverted.php
+++ b/domain/src/TaxYear/Events/CapitalLossReverted.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class CapitalLossReverted
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/IncomeRecorded.php
+++ b/domain/src/TaxYear/Events/IncomeRecorded.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class IncomeRecorded
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
+++ b/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\TaxYear\TaxYearId;
 use Domain\ValueObjects\FiatAmount;
 
 final class NonAttributableAllowableCostRecorded
 {
     public function __construct(
-        public readonly TaxYearId $taxYearId,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -22,7 +22,7 @@ use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
 
-/** @property \Domain\TaxYear\TaxYearId $aggregateRootId */
+/** @property TaxYearId $aggregateRootId */
 class TaxYear implements AggregateRoot
 {
     use AggregateRootBehaviour;

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -21,6 +21,7 @@ use Domain\TaxYear\Exceptions\TaxYearException;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
+use EventSauce\EventSourcing\AggregateRootId;
 
 /** @property TaxYearId $aggregateRootId */
 class TaxYear implements AggregateRoot
@@ -31,6 +32,11 @@ class TaxYear implements AggregateRoot
     private ?FiatAmount $capitalGainOrLoss = null;
     private ?FiatAmount $income = null;
     private ?FiatAmount $nonAttributableAllowableCosts = null;
+
+    private function __construct(AggregateRootId $aggregateRootId)
+    {
+        $this->aggregateRootId = TaxYearId::fromString($aggregateRootId->toString());
+    }
 
     public function recordCapitalGain(RecordCapitalGain $action): void
     {

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -22,6 +22,7 @@ use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
 
+/** @property \Domain\TaxYear\TaxYearId $aggregateRootId */
 class TaxYear implements AggregateRoot
 {
     use AggregateRootBehaviour;
@@ -35,13 +36,13 @@ class TaxYear implements AggregateRoot
     {
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRecordCapitalGainForDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new CapitalGainRecorded(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new CapitalGainRecorded(amount: $action->amount));
     }
 
     public function applyCapitalGainRecorded(CapitalGainRecorded $event): void
@@ -53,18 +54,18 @@ class TaxYear implements AggregateRoot
     public function revertCapitalGain(RevertCapitalGain $action): void
     {
         if (is_null($this->capitalGainOrLoss)) {
-            throw TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(taxYearId: $action->taxYearId);
+            throw TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(taxYearId: $this->aggregateRootId);
         }
 
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new CapitalGainReverted(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new CapitalGainReverted(amount: $action->amount));
     }
 
     public function applyCapitalGainReverted(CapitalGainReverted $event): void
@@ -78,13 +79,13 @@ class TaxYear implements AggregateRoot
     {
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRecordCapitalLossForDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new CapitalLossRecorded(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new CapitalLossRecorded(amount: $action->amount));
     }
 
     public function applyCapitalLossRecorded(CapitalLossRecorded $event): void
@@ -97,18 +98,18 @@ class TaxYear implements AggregateRoot
     public function revertCapitalLoss(RevertCapitalLoss $action): void
     {
         if (is_null($this->capitalGainOrLoss)) {
-            throw TaxYearException::cannotRevertCapitalLossBeforeCapitalLossIsRecorded(taxYearId: $action->taxYearId);
+            throw TaxYearException::cannotRevertCapitalLossBeforeCapitalLossIsRecorded(taxYearId: $this->aggregateRootId);
         }
 
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRevertCapitalLossFromDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new CapitalLossReverted(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new CapitalLossReverted(amount: $action->amount));
     }
 
     public function applyCapitalLossReverted(CapitalLossReverted $event): void
@@ -122,13 +123,13 @@ class TaxYear implements AggregateRoot
     {
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRecordIncomeFromDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new IncomeRecorded(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new IncomeRecorded(amount: $action->amount));
     }
 
     public function applyIncomeRecorded(IncomeRecorded $event): void
@@ -141,13 +142,13 @@ class TaxYear implements AggregateRoot
     {
         if ($this->currency && $this->currency !== $action->amount->currency) {
             throw TaxYearException::cannotRecordNonAttributableAllowableCostFromDifferentCurrency(
-                taxYearId: $action->taxYearId,
+                taxYearId: $this->aggregateRootId,
                 from: $this->currency,
                 to: $action->amount->currency,
             );
         }
 
-        $this->recordThat(new NonAttributableAllowableCostRecorded(taxYearId: $action->taxYearId, amount: $action->amount));
+        $this->recordThat(new NonAttributableAllowableCostRecorded(amount: $action->amount));
     }
 
     public function applyNonAttributableAllowableCostRecorded(NonAttributableAllowableCostRecorded $event): void

--- a/domain/tests/Nft/NftTest.php
+++ b/domain/tests/Nft/NftTest.php
@@ -15,19 +15,13 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 uses(NftTestCase::class);
 
-beforeEach(function () {
-    $this->nftId = $this->aggregateRootId();
-});
-
 it('can acquire a NFT', function () {
     $acquireNft = new AcquireNft(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $nftAcquired = new NftAcquired(
-        nftId: $acquireNft->nftId,
         date: $acquireNft->date,
         costBasis: $acquireNft->costBasis,
     );
@@ -39,18 +33,16 @@ it('can acquire a NFT', function () {
 
 it('cannot acquire the same NFT more than once', function () {
     $nftAcquired = new NftAcquired(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $acquireSameNft = new AcquireNft(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
-    $alreadyAcquired = NftException::alreadyAcquired($acquireSameNft->nftId);
+    $alreadyAcquired = NftException::alreadyAcquired($this->aggregateRootId);
 
     /** @var AggregateRootTestCase $this */
     $this->given($nftAcquired)
@@ -60,19 +52,16 @@ it('cannot acquire the same NFT more than once', function () {
 
 it('can increase the cost basis of a NFT', function () {
     $nftAcquired = new NftAcquired(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $increaseNftCostBasis = new IncreaseNftCostBasis(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: new FiatAmount('50', FiatCurrency::GBP),
     );
 
     $nftCostBasisIncreased = new NftCostBasisIncreased(
-        nftId: $increaseNftCostBasis->nftId,
         date: $increaseNftCostBasis->date,
         costBasisIncrease: $increaseNftCostBasis->costBasisIncrease,
     );
@@ -85,12 +74,11 @@ it('can increase the cost basis of a NFT', function () {
 
 it('cannot increase the cost basis of a NFT that has not been acquired', function () {
     $increaseNftCostBasis = new IncreaseNftCostBasis(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: new FiatAmount('100', FiatCurrency::GBP),
     );
 
-    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisBeforeAcquisition($increaseNftCostBasis->nftId);
+    $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId);
 
     /** @var AggregateRootTestCase $this */
     $this->when($increaseNftCostBasis)
@@ -99,19 +87,17 @@ it('cannot increase the cost basis of a NFT that has not been acquired', functio
 
 it('cannot increase the cost basis of a NFT because the currency is different', function () {
     $nftAcquired = new NftAcquired(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $increaseNftCostBasis = new IncreaseNftCostBasis(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     $cannotIncreaseCostBasis = NftException::cannotIncreaseCostBasisFromDifferentCurrency(
-        nftId: $increaseNftCostBasis->nftId,
+        nftId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -124,19 +110,16 @@ it('cannot increase the cost basis of a NFT because the currency is different', 
 
 it('can dispose of a NFT', function () {
     $nftAcquired = new NftAcquired(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $disposeOfNft = new DisposeOfNft(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         proceeds: new FiatAmount('150', FiatCurrency::GBP),
     );
 
     $nftDisposedOf = new NftDisposedOf(
-        nftId: $disposeOfNft->nftId,
         date: $disposeOfNft->date,
         costBasis: $nftAcquired->costBasis,
         proceeds: $disposeOfNft->proceeds,
@@ -150,12 +133,11 @@ it('can dispose of a NFT', function () {
 
 it('cannot dispose of a NFT that has not been acquired', function () {
     $disposeOfNft = new DisposeOfNft(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         proceeds: new FiatAmount('100', FiatCurrency::GBP),
     );
 
-    $cannotDisposeOf = NftException::cannotDisposeOfBeforeAcquisition($disposeOfNft->nftId);
+    $cannotDisposeOf = NftException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId);
 
     /** @var AggregateRootTestCase $this */
     $this->when($disposeOfNft)

--- a/domain/tests/Nft/NftTestCase.php
+++ b/domain/tests/Nft/NftTestCase.php
@@ -24,7 +24,7 @@ abstract class NftTestCase extends AggregateRootTestCase
 
     public function handle(object $action)
     {
-        $nft = $this->repository->retrieve($action->nftId);
+        $nft = $this->repository->retrieve($this->aggregateRootId);
 
         match ($action::class) {
             AcquireNft::class => $nft->acquire($action),

--- a/domain/tests/Nft/Reactors/NftReactorTest.php
+++ b/domain/tests/Nft/Reactors/NftReactorTest.php
@@ -3,7 +3,6 @@
 use Brick\DateTime\LocalDate;
 use Domain\Enums\FiatCurrency;
 use Domain\Nft\Events\NftDisposedOf;
-use Domain\Nft\NftId;
 use Domain\TaxYear\Actions\RecordCapitalGain;
 use Domain\TaxYear\Actions\RecordCapitalLoss;
 use Domain\TaxYear\TaxYear;
@@ -14,24 +13,19 @@ use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
 
 uses(NftReactorTestCase::class);
 
-beforeEach(function () {
-    $this->nftId = NftId::generate();
-});
-
 it('can handle a capital gain', function () {
     $taxYearSpy = Mockery::spy(TaxYear::class);
     $this->taxYearRepository->shouldReceive('get')->once()->andReturn($taxYearSpy);
     $this->taxYearRepository->shouldReceive('save')->once()->with($taxYearSpy);
 
     $nftDisposedOf = new NftDisposedOf(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
         proceeds: new FiatAmount('101', FiatCurrency::GBP),
     );
 
     /** @var MessageConsumerTestCase $this */
-    $this->givenNextMessagesHaveAggregateRootIdOf($this->nftId)
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($nftDisposedOf))
         ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalGain')
             ->once()
@@ -44,14 +38,13 @@ it('can handle a capital loss', function () {
     $this->taxYearRepository->shouldReceive('save')->once()->with($taxYearSpy);
 
     $nftDisposedOf = new NftDisposedOf(
-        nftId: $this->nftId,
         date: LocalDate::parse('2015-10-21'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
         proceeds: new FiatAmount('99', FiatCurrency::GBP),
     );
 
     /** @var MessageConsumerTestCase $this */
-    $this->givenNextMessagesHaveAggregateRootIdOf($this->nftId)
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($nftDisposedOf))
         ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalLoss')
             ->once()

--- a/domain/tests/Nft/Reactors/NftReactorTestCase.php
+++ b/domain/tests/Nft/Reactors/NftReactorTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Domain\Tests\Nft\Reactors;
 
+use Domain\Nft\NftId;
 use Domain\Nft\Reactors\NftReactor;
 use Domain\TaxYear\Repositories\TaxYearRepository;
 use EventSauce\EventSourcing\MessageConsumer;
@@ -11,7 +12,15 @@ use Mockery\MockInterface;
 
 class NftReactorTestCase extends MessageConsumerTestCase
 {
+    protected $aggregateRootId;
     protected MockInterface $taxYearRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->aggregateRootId = NftId::generate();
+    }
 
     public function messageConsumer(): MessageConsumer
     {

--- a/domain/tests/SharePooling/SharePoolingTest.php
+++ b/domain/tests/SharePooling/SharePoolingTest.php
@@ -18,20 +18,14 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 uses(SharePoolingTestCase::class);
 
-beforeEach(function () {
-    $this->sharePoolingId = $this->aggregateRootId();
-});
-
 it('can acquire some share pooling tokens', function () {
     $acquireSharePoolingToken = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $sharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: $acquireSharePoolingToken->date,
             quantity: new Quantity('100'),
@@ -46,7 +40,6 @@ it('can acquire some share pooling tokens', function () {
 
 it('can acquire more of the same share pooling tokens', function () {
     $someSharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -55,14 +48,12 @@ it('can acquire more of the same share pooling tokens', function () {
     );
 
     $acquireMoreSharePoolingToken = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: new FiatAmount('300', FiatCurrency::GBP),
     );
 
     $moreSharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: (new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -78,7 +69,6 @@ it('can acquire more of the same share pooling tokens', function () {
 
 it('cannot acquire more of the same share pooling tokens because currencies don\'t match', function () {
     $someSharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -87,14 +77,13 @@ it('cannot acquire more of the same share pooling tokens because currencies don\
     );
 
     $acquireMoreSharePoolingToken = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: new FiatAmount('300', FiatCurrency::EUR),
     );
 
     $cannotAcquireSharePoolingToken = SharePoolingException::cannotAcquireFromDifferentCurrency(
-        sharePoolingId: $this->sharePoolingId,
+        sharePoolingId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -107,7 +96,6 @@ it('cannot acquire more of the same share pooling tokens because currencies don\
 
 it('can dispose of some share pooling tokens', function () {
     $sharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -116,14 +104,12 @@ it('can dispose of some share pooling tokens', function () {
     );
 
     $disposeOfSharePoolingToken = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('50'),
         proceeds: new FiatAmount('150', FiatCurrency::GBP),
     );
 
     $sharePoolingTokenDisposedOf = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: (new SharePoolingTokenDisposal(
             date: $disposeOfSharePoolingToken->date,
             quantity: $disposeOfSharePoolingToken->quantity,
@@ -142,7 +128,6 @@ it('can dispose of some share pooling tokens', function () {
 
 it('cannot dispose of some share pooling tokens because currencies don\'t match', function () {
     $sharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -151,14 +136,13 @@ it('cannot dispose of some share pooling tokens because currencies don\'t match'
     );
 
     $disposeOfSharePoolingToken = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('100'),
         proceeds: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     $cannotDisposeOfSharePoolingToken = SharePoolingException::cannotDisposeOfFromDifferentCurrency(
-        sharePoolingId: $this->sharePoolingId,
+        sharePoolingId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -171,7 +155,6 @@ it('cannot dispose of some share pooling tokens because currencies don\'t match'
 
 it('cannot dispose of some share pooling tokens because the quantity is too high', function () {
     $sharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -180,14 +163,13 @@ it('cannot dispose of some share pooling tokens because the quantity is too high
     );
 
     $disposeOfSharePoolingToken = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('101'),
         proceeds: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $cannotDisposeOfSharePoolingToken = SharePoolingException::insufficientQuantity(
-        sharePoolingId: $this->sharePoolingId,
+        sharePoolingId: $this->aggregateRootId,
         disposalQuantity: $disposeOfSharePoolingToken->quantity,
         availableQuantity: new Quantity('100'),
     );
@@ -200,7 +182,6 @@ it('cannot dispose of some share pooling tokens because the quantity is too high
 
 it('can dispose of some share pooling tokens on the same day they were acquired', function () {
     $someSharePoolingTokensAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -209,7 +190,6 @@ it('can dispose of some share pooling tokens on the same day they were acquired'
     );
 
     $moreSharePoolingTokensAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('100'),
@@ -218,14 +198,12 @@ it('can dispose of some share pooling tokens on the same day they were acquired'
     );
 
     $disposeOfSharePoolingToken = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-26'),
         quantity: new Quantity('150'),
         proceeds: new FiatAmount('300', FiatCurrency::GBP),
     );
 
     $sharePoolingTokenDisposedOf = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('100'), position: 1) // $moreSharePoolingTokensAcquired
             ->make([
@@ -247,7 +225,6 @@ it('can acquire some share pooling tokens within 30 days of their disposal', fun
     // Given
 
     $someSharePoolingTokensAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -256,7 +233,6 @@ it('can acquire some share pooling tokens within 30 days of their disposal', fun
     );
 
     $someSharePoolingTokensDisposedOf = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: new SharePoolingTokenDisposal(
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('50'),
@@ -270,7 +246,6 @@ it('can acquire some share pooling tokens within 30 days of their disposal', fun
     // When
 
     $acquireMoreSharePoolingToken = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('25'),
         costBasis: new FiatAmount('20', FiatCurrency::GBP),
@@ -279,12 +254,10 @@ it('can acquire some share pooling tokens within 30 days of their disposal', fun
     // Then
 
     $sharePoolingTokenDisposalReverted = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $someSharePoolingTokensDisposedOf->sharePoolingTokenDisposal,
     );
 
     $moreSharePoolingTokenAcquired = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: (new SharePoolingTokenAcquisition(
             date: $acquireMoreSharePoolingToken->date,
             quantity: $acquireMoreSharePoolingToken->quantity,
@@ -294,7 +267,6 @@ it('can acquire some share pooling tokens within 30 days of their disposal', fun
     );
 
     $correctedSharePoolingTokensDisposedOf = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->copyFrom($someSharePoolingTokensDisposedOf->sharePoolingTokenDisposal)
             ->withThirtyDayQuantity(new Quantity('25'), position: 2) // $acquireMoreSharePoolingToken
@@ -315,7 +287,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     // Given
 
     $sharePoolingTokenAcquired1 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -324,7 +295,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenAcquired2 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
@@ -334,7 +304,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenDisposedOf1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), position: 1) // $sharePoolingTokenAcquired2
             ->withThirtyDayQuantity(new Quantity('20'), position: 4) // $sharePoolingTokenAcquired3
@@ -346,7 +315,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenDisposedOf2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: new SharePoolingTokenDisposal(
             date: LocalDate::parse('2015-10-25'),
             quantity: new Quantity('25'),
@@ -358,7 +326,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenAcquired3 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
@@ -368,19 +335,16 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenDisposal1Reverted1 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposedOf1Corrected1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1->sharePoolingTokenDisposal,
     );
 
     // When
 
     $acquireSharePoolingToken4 = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('20'),
         costBasis: new FiatAmount('40', FiatCurrency::GBP),
@@ -389,17 +353,14 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     // Then
 
     $sharePoolingTokenDisposal1Reverted2 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1Corrected1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposal2Reverted = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf2->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired4 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: (new SharePoolingTokenAcquisition(
             date: $acquireSharePoolingToken4->date,
             quantity: $acquireSharePoolingToken4->quantity,
@@ -409,7 +370,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenDisposedOf1Corrected2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->copyFrom($sharePoolingTokenDisposedOf1Corrected1->sharePoolingTokenDisposal)
             ->withThirtyDayQuantity(new Quantity('5'), position: 5) // $sharePoolingTokenAcquired4
@@ -418,7 +378,6 @@ it('can acquire some share pooling tokens several times within 30 days of their 
     );
 
     $sharePoolingTokenDisposedOf2Corrected = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->copyFrom($sharePoolingTokenDisposedOf2->sharePoolingTokenDisposal)
             ->withThirtyDayQuantity(new Quantity('15'), position: 5) // $sharePoolingTokenAcquired4
@@ -453,7 +412,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     // Given
 
     $sharePoolingTokenAcquired1 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -462,7 +420,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenAcquired2 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
@@ -472,7 +429,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenDisposedOf1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), position: 1) // $sharePoolingTokenAcquired2
             ->withThirtyDayQuantity(new Quantity('20'), position: 4) // $sharePoolingTokenAcquired3
@@ -485,7 +441,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenDisposedOf2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withThirtyDayQuantity(new Quantity('15'), position: 5) // $sharePoolingTokenAcquired4
             ->make([
@@ -496,7 +451,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenAcquired3 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
@@ -506,17 +460,14 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenDisposal1Reverted1 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposedOf1Corrected1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired4 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-29'),
             quantity: new Quantity('20'),
@@ -526,29 +477,24 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenDisposal1Reverted2 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1Corrected1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposal2Reverted1 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf2->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposedOf1Corrected2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1Corrected1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposedOf2Corrected1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf2->sharePoolingTokenDisposal,
     );
 
     // When
 
     $disposeOfSharePoolingToken3 = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('10'),
         proceeds: new FiatAmount('30', FiatCurrency::GBP),
@@ -557,12 +503,10 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     // Then
 
     $sharePoolingTokenDisposal2Reverted2 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf2Corrected1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenDisposedOf2Corrected2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->revert($sharePoolingTokenDisposedOf2->sharePoolingTokenDisposal)
             ->withThirtyDayQuantity(new Quantity('5'), position: 5) // $sharePoolingTokenAcquired4
@@ -571,7 +515,6 @@ it('can dispose of some share pooling tokens on the same day as an acquisition w
     );
 
     $sharePoolingTokenDisposedOf3 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: (
             SharePoolingTokenDisposal::factory()
                 ->withSameDayQuantity(new Quantity('10'), position: 5) // $sharePoolingTokenAcquired4
@@ -608,7 +551,6 @@ it('can acquire some same-day share pooling tokens several times on the same day
     // Given
 
     $sharePoolingTokenAcquired1 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -617,7 +559,6 @@ it('can acquire some same-day share pooling tokens several times on the same day
     );
 
     $sharePoolingTokenDisposedOf = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: new SharePoolingTokenDisposal(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
@@ -629,12 +570,10 @@ it('can acquire some same-day share pooling tokens several times on the same day
     );
 
     $sharePoolingTokenDisposalReverted = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired2 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
@@ -644,7 +583,6 @@ it('can acquire some same-day share pooling tokens several times on the same day
     );
 
     $sharePoolingTokenDisposedOfCorrected = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->revert($sharePoolingTokenDisposedOf->sharePoolingTokenDisposal)
             ->withSameDayQuantity(new Quantity('20'), position: 2) // $sharePoolingTokenAcquired2
@@ -659,7 +597,6 @@ it('can acquire some same-day share pooling tokens several times on the same day
     // When
 
     $acquireSharePoolingToken3 = new AcquireSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('10'),
         costBasis: new FiatAmount('14', FiatCurrency::GBP),
@@ -668,12 +605,10 @@ it('can acquire some same-day share pooling tokens several times on the same day
     // Then
 
     $sharePoolingTokenDisposalReverted2 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOfCorrected->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired3 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: (new SharePoolingTokenAcquisition(
             date: $acquireSharePoolingToken3->date,
             quantity: $acquireSharePoolingToken3->quantity,
@@ -683,7 +618,6 @@ it('can acquire some same-day share pooling tokens several times on the same day
     );
 
     $sharePoolingTokensDisposedOfCorrected2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->revert($sharePoolingTokenDisposedOfCorrected->sharePoolingTokenDisposal)
             ->withSameDayQuantity(new Quantity('20'), position: 2) // $sharePoolingTokenAcquired2
@@ -711,7 +645,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     // Given
 
     $sharePoolingTokenAcquired1 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
@@ -720,7 +653,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     );
 
     $sharePoolingTokenDisposedOf1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: new SharePoolingTokenDisposal(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
@@ -732,12 +664,10 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     );
 
     $sharePoolingTokenDisposalReverted1 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired2 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
@@ -747,7 +677,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     );
 
     $sharePoolingTokenDisposedOf1Corrected1 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('20'), position: 2) // $sharePoolingTokenAcquired2
             ->make([
@@ -759,12 +688,10 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     );
 
     $sharePoolingTokenDisposalReverted2 = new SharePoolingTokenDisposalReverted(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: $sharePoolingTokenDisposedOf1Corrected1->sharePoolingTokenDisposal,
     );
 
     $sharePoolingTokenAcquired3 = new SharePoolingTokenAcquired(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenAcquisition: new SharePoolingTokenAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('60'),
@@ -774,7 +701,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     );
 
     $sharePoolingTokenDisposedOf1Corrected2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('20'), position: 2) // $sharePoolingTokenAcquired2
             ->withSameDayQuantity(new Quantity('30'), position: 3) // $sharePoolingTokenAcquired3
@@ -789,7 +715,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     // When
 
     $disposeOfSharePoolingToken2 = new DisposeOfSharePoolingToken(
-        sharePoolingId: $this->sharePoolingId,
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('40'),
         proceeds: new FiatAmount('50', FiatCurrency::GBP),
@@ -798,7 +723,6 @@ it('can dispose of some same-day share pooling tokens several times on the same 
     // Then
 
     $sharePoolingTokenDisposedOf2 = new SharePoolingTokenDisposedOf(
-        sharePoolingId: $this->sharePoolingId,
         sharePoolingTokenDisposal: (
             SharePoolingTokenDisposal::factory()
             ->withSameDayQuantity(new Quantity('30'), position: 3) // $sharePoolingTokenAcquired3

--- a/domain/tests/SharePooling/SharePoolingTestCase.php
+++ b/domain/tests/SharePooling/SharePoolingTestCase.php
@@ -23,7 +23,7 @@ abstract class SharePoolingTestCase extends AggregateRootTestCase
 
     public function handle(object $action)
     {
-        $sharePooling = $this->repository->retrieve($action->sharePoolingId);
+        $sharePooling = $this->repository->retrieve($this->aggregateRootId);
 
         match ($action::class) {
             AcquireSharePoolingToken::class => $sharePooling->acquire($action),

--- a/domain/tests/TaxYear/TaxYearTest.php
+++ b/domain/tests/TaxYear/TaxYearTest.php
@@ -20,20 +20,9 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 uses(TaxYearTestCase::class);
 
-beforeEach(function () {
-    $this->taxYearId = $this->aggregateRootId();
-});
-
 it('can record a capital gain', function () {
-    $recordCapitalGain = new RecordCapitalGain(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $capitalGainRecorded = new CapitalGainRecorded(
-        taxYearId: $recordCapitalGain->taxYearId,
-        amount: $recordCapitalGain->amount,
-    );
+    $recordCapitalGain = new RecordCapitalGain(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalGainRecorded = new CapitalGainRecorded(amount: $recordCapitalGain->amount);
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordCapitalGain)
@@ -41,18 +30,11 @@ it('can record a capital gain', function () {
 });
 
 it('cannot record a capital gain because the currency is different', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $recordCapitalGain = new RecordCapitalGain(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $recordCapitalGain = new RecordCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
 
     $cannotRecordCapitalGain = TaxYearException::cannotRecordCapitalGainForDifferentCurrency(
-        taxYearId: $recordCapitalGain->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -64,20 +46,9 @@ it('cannot record a capital gain because the currency is different', function ()
 });
 
 it('can revert a capital gain', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $revertCapitalGain = new RevertCapitalGain(
-        taxYearId: $capitalGainRecorded->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $capitalGainReverted = new CapitalGainReverted(
-        taxYearId: $capitalGainRecorded->taxYearId,
-        amount: $revertCapitalGain->amount,
-    );
+    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalGainReverted = new CapitalGainReverted(amount: $revertCapitalGain->amount);
 
     /** @var AggregateRootTestCase $this */
     $this->given($capitalGainRecorded)
@@ -86,13 +57,9 @@ it('can revert a capital gain', function () {
 });
 
 it('cannot revert a capital gain before a capital gain was recorded', function () {
-    $revertCapitalGain = new RevertCapitalGain(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
-
+    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
     $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(
-        taxYearId: $revertCapitalGain->taxYearId,
+        taxYearId: $this->aggregateRootId,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -101,18 +68,11 @@ it('cannot revert a capital gain before a capital gain was recorded', function (
 });
 
 it('cannot revert a capital gain because the currency is different', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $revertCapitalGain = new RevertCapitalGain(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
 
     $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
-        taxYearId: $revertCapitalGain->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -124,15 +84,8 @@ it('cannot revert a capital gain because the currency is different', function ()
 });
 
 it('can record a capital loss', function () {
-    $recordCapitalLoss = new RecordCapitalLoss(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $capitalLossRecorded = new CapitalLossRecorded(
-        taxYearId: $recordCapitalLoss->taxYearId,
-        amount: $recordCapitalLoss->amount,
-    );
+    $recordCapitalLoss = new RecordCapitalLoss(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalLossRecorded = new CapitalLossRecorded(amount: $recordCapitalLoss->amount);
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordCapitalLoss)
@@ -140,18 +93,11 @@ it('can record a capital loss', function () {
 });
 
 it('cannot record a capital loss because the currency is different', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $recordCapitalLoss = new RecordCapitalLoss(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $recordCapitalLoss = new RecordCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
 
     $cannotRecordCapitalLoss = TaxYearException::cannotRecordCapitalLossForDifferentCurrency(
-        taxYearId: $recordCapitalLoss->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -163,20 +109,9 @@ it('cannot record a capital loss because the currency is different', function ()
 });
 
 it('can revert a capital loss', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $revertCapitalLoss = new RevertCapitalLoss(
-        taxYearId: $capitalLossRecorded->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $capitalLossReverted = new CapitalLossReverted(
-        taxYearId: $capitalLossRecorded->taxYearId,
-        amount: $revertCapitalLoss->amount,
-    );
+    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalLossReverted = new CapitalLossReverted(amount: $revertCapitalLoss->amount);
 
     /** @var AggregateRootTestCase $this */
     $this->given($capitalLossRecorded)
@@ -185,13 +120,9 @@ it('can revert a capital loss', function () {
 });
 
 it('cannot revert a capital loss before a capital loss was recorded', function () {
-    $revertCapitalLoss = new RevertCapitalLoss(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
-
+    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
     $cannotRevertCapitalLoss = TaxYearException::cannotRevertCapitalLossBeforeCapitalLossIsRecorded(
-        taxYearId: $revertCapitalLoss->taxYearId,
+        taxYearId: $this->aggregateRootId,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -200,18 +131,11 @@ it('cannot revert a capital loss before a capital loss was recorded', function (
 });
 
 it('cannot revert a capital loss because the currency is different', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $revertCapitalLoss = new RevertCapitalLoss(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
 
     $cannotRevertCapitalLoss = TaxYearException::cannotRevertCapitalLossFromDifferentCurrency(
-        taxYearId: $revertCapitalLoss->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -223,15 +147,8 @@ it('cannot revert a capital loss because the currency is different', function ()
 });
 
 it('can record some income', function () {
-    $recordIncome = new RecordIncome(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $incomeRecorded = new IncomeRecorded(
-        taxYearId: $recordIncome->taxYearId,
-        amount: $recordIncome->amount,
-    );
+    $recordIncome = new RecordIncome(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $incomeRecorded = new IncomeRecorded(amount: $recordIncome->amount);
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordIncome)
@@ -239,18 +156,11 @@ it('can record some income', function () {
 });
 
 it('cannot record some income because the currency is different', function () {
-    $incomeRecorded = new IncomeRecorded(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::GBP),
-    );
-
-    $recordIncome = new RecordIncome(
-        taxYearId: $this->taxYearId,
-        amount: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    $incomeRecorded = new IncomeRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $recordIncome = new RecordIncome(amount: new FiatAmount('100', FiatCurrency::EUR));
 
     $cannotRecordIncome = TaxYearException::cannotRecordIncomeFromDifferentCurrency(
-        taxYearId: $recordIncome->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );
@@ -263,12 +173,10 @@ it('cannot record some income because the currency is different', function () {
 
 it('can record a non-attributable allowable cost', function () {
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
-        taxYearId: $this->taxYearId,
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
-        taxYearId: $recordNonAttributableAllowableCost->taxYearId,
         amount: $recordNonAttributableAllowableCost->amount,
     );
 
@@ -279,17 +187,15 @@ it('can record a non-attributable allowable cost', function () {
 
 it('cannot record a non-attributable allowable cost because the currency is different', function () {
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
-        taxYearId: $this->taxYearId,
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
-        taxYearId: $this->taxYearId,
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     $cannotRecordNonAttributableAllowableCost = TaxYearException::cannotRecordNonAttributableAllowableCostFromDifferentCurrency(
-        taxYearId: $recordNonAttributableAllowableCost->taxYearId,
+        taxYearId: $this->aggregateRootId,
         from: FiatCurrency::GBP,
         to: FiatCurrency::EUR,
     );

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -27,7 +27,7 @@ abstract class TaxYearTestCase extends AggregateRootTestCase
 
     public function handle(object $action)
     {
-        $taxYear = $this->repository->retrieve($action->taxYearId);
+        $taxYear = $this->repository->retrieve($this->aggregateRootId);
 
         match ($action::class) {
             RecordCapitalGain::class => $taxYear->recordCapitalGain($action),


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR removes the aggregate rout ID as a property from all actions and events.

## Explanation <!-- deeper explanation to guide reviewers -->

I realised having it there is completely redundant 🙃 

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
