### PR TITLE
Share pooling reactor

### DIFF
--- a/app/SharePooling/SharePoolingMessageRepository.php
+++ b/app/SharePooling/SharePoolingMessageRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SharePooling;
+
+use Domain\SharePooling\Repositories\SharePoolingMessageRepository as SharePoolingMessageRepositoryInterface;
+use EventSauce\MessageRepository\IlluminateMessageRepository\IlluminateUuidV4MessageRepository;
+
+class SharePoolingMessageRepository extends IlluminateUuidV4MessageRepository implements SharePoolingMessageRepositoryInterface
+{
+}

--- a/app/SharePooling/SharePoolingRepository.php
+++ b/app/SharePooling/SharePoolingRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SharePooling;
+
+use Domain\SharePooling\Repositories\SharePoolingRepository as SharePoolingRepositoryInterface;
+use Domain\SharePooling\SharePooling;
+use Domain\SharePooling\SharePoolingId;
+use EventSauce\EventSourcing\ClassNameInflector;
+use EventSauce\EventSourcing\EventSourcedAggregateRootRepository;
+use EventSauce\EventSourcing\MessageDecorator;
+use EventSauce\EventSourcing\MessageDispatcher;
+use EventSauce\EventSourcing\MessageRepository;
+
+/** @extends EventSourcedAggregateRootRepository<SharePooling> */
+final class SharePoolingRepository extends EventSourcedAggregateRootRepository implements SharePoolingRepositoryInterface
+{
+    public function __construct(
+        MessageRepository $messageRepository,
+        MessageDispatcher $dispatcher,
+        MessageDecorator $decorator,
+        ClassNameInflector $classNameInflector,
+    ) {
+        parent::__construct(SharePooling::class, $messageRepository, $dispatcher, $decorator, $classNameInflector);
+    }
+
+    public function get(SharePoolingId $sharePoolingId): SharePooling
+    {
+        return $this->retrieve($sharePoolingId);
+    }
+}

--- a/app/SharePooling/SharePoolingServiceProvider.php
+++ b/app/SharePooling/SharePoolingServiceProvider.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Nft;
+namespace App\SharePooling;
 
-use Domain\Nft\Reactors\NftReactor;
-use Domain\Nft\Repositories\NftMessageRepository as NftMessageRepositoryInterface;
-use Domain\Nft\Repositories\NftRepository as NftRepositoryInterface;
+use Domain\SharePooling\Reactors\SharePoolingReactor;
+use Domain\SharePooling\Repositories\SharePoolingMessageRepository as SharePoolingMessageRepositoryInterface;
+use Domain\SharePooling\Repositories\SharePoolingRepository as SharePoolingRepositoryInterface;
 use EventSauce\EventSourcing\DefaultHeadersDecorator;
 use EventSauce\EventSourcing\ExplicitlyMappedClassNameInflector;
 use EventSauce\EventSourcing\MessageDecoratorChain;
@@ -19,7 +19,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
 use LaravelZero\Framework\Application;
 
-class NftServiceProvider extends ServiceProvider
+class SharePoolingServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
@@ -31,10 +31,10 @@ class NftServiceProvider extends ServiceProvider
         // @phpstan-ignore-next-line
         $classNameInflector = new ExplicitlyMappedClassNameInflector(config('eventsourcing.class_map'));
 
-        $this->app->bind(NftMessageRepositoryInterface::class, fn (Application $app) => new NftMessageRepository(
+        $this->app->bind(SharePoolingMessageRepositoryInterface::class, fn (Application $app) => new SharePoolingMessageRepository(
             // @phpstan-ignore-next-line
             connection: $app->make(DatabaseManager::class)->connection(),
-            tableName: 'nft_events',
+            tableName: 'share_pooling_events',
             serializer: new ConstructingMessageSerializer(
                 $classNameInflector,
                 new PayloadSerializerSupportingObjectMapperAndSerializablePayload(),
@@ -42,11 +42,11 @@ class NftServiceProvider extends ServiceProvider
             uuidEncoder: new StringUuidEncoder(),
         ));
 
-        $this->app->bind(NftRepositoryInterface::class, fn () => new NftRepository(
+        $this->app->bind(SharePoolingRepositoryInterface::class, fn () => new SharePoolingRepository(
             // @phpstan-ignore-next-line
-            $this->app->make(NftMessageRepositoryInterface::class),
+            $this->app->make(SharePoolingMessageRepositoryInterface::class),
             // @phpstan-ignore-next-line
-            new MessageDispatcherChain(new SynchronousMessageDispatcher($this->app->make(NftReactor::class))),
+            new MessageDispatcherChain(new SynchronousMessageDispatcher($this->app->make(SharePoolingReactor::class))),
             new MessageDecoratorChain(new DefaultHeadersDecorator($classNameInflector)),
             $classNameInflector,
         ));

--- a/config/app.php
+++ b/config/app.php
@@ -71,6 +71,7 @@ return [
     'providers' => [
         App\Providers\AppServiceProvider::class,
         App\Nft\NftServiceProvider::class,
+        App\SharePooling\SharePoolingServiceProvider::class,
         App\TaxYear\TaxYearServiceProvider::class,
     ],
 

--- a/config/eventsourcing.php
+++ b/config/eventsourcing.php
@@ -7,6 +7,11 @@ use Domain\Nft\Events\NftCostBasisIncreased;
 use Domain\Nft\Events\NftDisposedOf;
 use Domain\Nft\Nft;
 use Domain\Nft\NftId;
+use Domain\SharePooling\Events\SharePoolingTokenAcquired;
+use Domain\SharePooling\Events\SharePoolingTokenDisposalReverted;
+use Domain\SharePooling\Events\SharePoolingTokenDisposedOf;
+use Domain\SharePooling\SharePooling;
+use Domain\SharePooling\SharePoolingId;
 
 return [
     'class_map' => [
@@ -15,5 +20,10 @@ return [
         NftAcquired::class => 'nft.nft_acquired',
         NftCostBasisIncreased::class => 'nft.nft_cost_basis_increased',
         NftDisposedOf::class => 'nft.nft_disposed_of',
+        SharePooling::class => 'share_pooling.share_pooling',
+        SharePoolingId::class => 'share_pooling.share_pooling_id',
+        SharePoolingTokenAcquired::class => 'share_pooling.share_pooling_acquired',
+        SharePoolingTokenDisposalReverted::class => 'share_pooling.share_pooling_disposal_reverted',
+        SharePoolingTokenDisposedOf::class => 'share_pooling.share_pooling_disposed_of',
     ],
 ];

--- a/database/migrations/2022_11_27_122348_create_share_pooling_events_table.php
+++ b/database/migrations/2022_11_27_122348_create_share_pooling_events_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('share_pooling_events', function (Blueprint $table) {
+            $table->uuid('event_id');
+            $table->uuid('aggregate_root_id');
+            $table->unsignedInteger('version')->nullable();
+            $table->jsonb('payload');
+
+            $table->unique(['aggregate_root_id', 'version']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('share_pooling_events');
+    }
+};

--- a/domain/src/Nft/Events/NftAcquired.php
+++ b/domain/src/Nft/Events/NftAcquired.php
@@ -21,7 +21,7 @@ final class NftAcquired implements SerializablePayload
     {
         return [
             'date' => $this->date->__toString(),
-            'cost_basis' => $this->costBasis->toArray(),
+            'cost_basis' => $this->costBasis->toPayload(),
         ];
     }
 
@@ -30,7 +30,7 @@ final class NftAcquired implements SerializablePayload
     {
         return new static(
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
-            FiatAmount::fromArray($payload['cost_basis']), // @phpstan-ignore-line
+            FiatAmount::fromPayload($payload['cost_basis']), // @phpstan-ignore-line
         );
     }
 }

--- a/domain/src/Nft/Events/NftCostBasisIncreased.php
+++ b/domain/src/Nft/Events/NftCostBasisIncreased.php
@@ -21,7 +21,7 @@ final class NftCostBasisIncreased implements SerializablePayload
     {
         return [
             'date' => $this->date->__toString(),
-            'cost_basis_increase' => $this->costBasisIncrease->toArray(),
+            'cost_basis_increase' => $this->costBasisIncrease->toPayload(),
         ];
     }
 
@@ -30,7 +30,7 @@ final class NftCostBasisIncreased implements SerializablePayload
     {
         return new static(
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
-            FiatAmount::fromArray($payload['cost_basis_increase']), // @phpstan-ignore-line
+            FiatAmount::fromPayload($payload['cost_basis_increase']), // @phpstan-ignore-line
         );
     }
 }

--- a/domain/src/Nft/Events/NftDisposedOf.php
+++ b/domain/src/Nft/Events/NftDisposedOf.php
@@ -22,8 +22,8 @@ final class NftDisposedOf implements SerializablePayload
     {
         return [
             'date' => $this->date->__toString(),
-            'cost_basis' => $this->costBasis->toArray(),
-            'proceeds' => $this->proceeds->toArray(),
+            'cost_basis' => $this->costBasis->toPayload(),
+            'proceeds' => $this->proceeds->toPayload(),
         ];
     }
 
@@ -32,8 +32,8 @@ final class NftDisposedOf implements SerializablePayload
     {
         return new static(
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
-            FiatAmount::fromArray($payload['cost_basis']), // @phpstan-ignore-line
-            FiatAmount::fromArray($payload['proceeds']), // @phpstan-ignore-line
+            FiatAmount::fromPayload($payload['cost_basis']), // @phpstan-ignore-line
+            FiatAmount::fromPayload($payload['proceeds']), // @phpstan-ignore-line
         );
     }
 }

--- a/domain/src/SharePooling/Events/SharePoolingTokenAcquired.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenAcquired.php
@@ -5,11 +5,25 @@ declare(strict_types=1);
 namespace Domain\SharePooling\Events;
 
 use Domain\SharePooling\ValueObjects\SharePoolingTokenAcquisition;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class SharePoolingTokenAcquired
+final class SharePoolingTokenAcquired implements SerializablePayload
 {
     public function __construct(
         public readonly SharePoolingTokenAcquisition $sharePoolingTokenAcquisition,
     ) {
+    }
+
+    /** @return array<string, string|array<string, string|array<string, string>>> */
+    public function toPayload(): array
+    {
+        return ['share_pooling_token_acquisition' => $this->sharePoolingTokenAcquisition->toPayload()];
+    }
+
+    /** @param array<string, string|array<string, string|array<string, string>>> $payload */
+    public static function fromPayload(array $payload): static
+    {
+        // @phpstan-ignore-next-line
+        return new static(SharePoolingTokenAcquisition::fromPayload($payload['share_pooling_token_acquisition']));
     }
 }

--- a/domain/src/SharePooling/Events/SharePoolingTokenDisposalReverted.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenDisposalReverted.php
@@ -5,11 +5,25 @@ declare(strict_types=1);
 namespace Domain\SharePooling\Events;
 
 use Domain\SharePooling\ValueObjects\SharePoolingTokenDisposal;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class SharePoolingTokenDisposalReverted
+final class SharePoolingTokenDisposalReverted implements SerializablePayload
 {
     public function __construct(
         public readonly SharePoolingTokenDisposal $sharePoolingTokenDisposal,
     ) {
+    }
+
+    /** @return array<string, string|array<string, string|array<string, string|array<string>>>> */
+    public function toPayload(): array
+    {
+        return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
+    }
+
+    /** @param array<string, string|array<string, string|array<string, string|array<string>>>> $payload */
+    public static function fromPayload(array $payload): static
+    {
+        // @phpstan-ignore-next-line
+        return new static(SharePoolingTokenDisposal::fromPayload($payload['share_pooling_token_disposal']));
     }
 }

--- a/domain/src/SharePooling/Events/SharePoolingTokenDisposedOf.php
+++ b/domain/src/SharePooling/Events/SharePoolingTokenDisposedOf.php
@@ -5,11 +5,25 @@ declare(strict_types=1);
 namespace Domain\SharePooling\Events;
 
 use Domain\SharePooling\ValueObjects\SharePoolingTokenDisposal;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class SharePoolingTokenDisposedOf
+final class SharePoolingTokenDisposedOf implements SerializablePayload
 {
     public function __construct(
         public readonly SharePoolingTokenDisposal $sharePoolingTokenDisposal,
     ) {
+    }
+
+    /** @return array<string, string|array<string, string|array<string, string|array<string>>>> */
+    public function toPayload(): array
+    {
+        return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
+    }
+
+    /** @param array<string, string|array<string, string|array<string, string|array<string>>>> $payload */
+    public static function fromPayload(array $payload): static
+    {
+        // @phpstan-ignore-next-line
+        return new static(SharePoolingTokenDisposal::fromPayload($payload['share_pooling_token_disposal']));
     }
 }

--- a/domain/src/SharePooling/Reactors/SharePoolingReactor.php
+++ b/domain/src/SharePooling/Reactors/SharePoolingReactor.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\SharePooling\Reactors;
+
+use Domain\SharePooling\Events\SharePoolingTokenDisposalReverted;
+use Domain\SharePooling\Events\SharePoolingTokenDisposedOf;
+use Domain\TaxYear\Actions\RecordCapitalGain;
+use Domain\TaxYear\Actions\RecordCapitalLoss;
+use Domain\TaxYear\Actions\RevertCapitalGain;
+use Domain\TaxYear\Actions\RevertCapitalLoss;
+use Domain\TaxYear\Repositories\TaxYearRepository;
+use Domain\TaxYear\TaxYearId;
+use EventSauce\EventSourcing\EventConsumption\EventConsumer;
+use EventSauce\EventSourcing\Message;
+
+final class SharePoolingReactor extends EventConsumer
+{
+    public function __construct(private TaxYearRepository $taxYearRepository)
+    {
+    }
+
+    public function handleSharePoolingTokenDisposedOf(SharePoolingTokenDisposedOf $event, Message $message): void
+    {
+        $disposal = $event->sharePoolingTokenDisposal;
+        $taxYearId = TaxYearId::fromYear($disposal->date->getYear());
+        $taxYear = $this->taxYearRepository->get($taxYearId);
+
+        if ($disposal->proceeds->isGreaterThan($disposal->costBasis)) {
+            $taxYear->recordCapitalGain(new RecordCapitalGain(amount: $disposal->proceeds->minus($disposal->costBasis)));
+        } else {
+            $taxYear->recordCapitalLoss(new RecordCapitalLoss(amount: $disposal->costBasis->minus($disposal->proceeds)));
+        }
+
+        $this->taxYearRepository->save($taxYear);
+    }
+
+    public function handleSharePoolingTokenDisposalReverted(SharePoolingTokenDisposalReverted $event, Message $message): void
+    {
+        $disposal = $event->sharePoolingTokenDisposal;
+        $taxYearId = TaxYearId::fromYear($disposal->date->getYear());
+        $taxYear = $this->taxYearRepository->get($taxYearId);
+
+        if ($disposal->proceeds->isGreaterThan($disposal->costBasis)) {
+            $taxYear->revertCapitalGain(new RevertCapitalGain(amount: $disposal->proceeds->minus($disposal->costBasis)));
+        } else {
+            $taxYear->revertCapitalLoss(new RevertCapitalLoss(amount: $disposal->costBasis->minus($disposal->proceeds)));
+        }
+
+        $this->taxYearRepository->save($taxYear);
+    }
+}

--- a/domain/src/SharePooling/Repositories/SharePoolingMessageRepository.php
+++ b/domain/src/SharePooling/Repositories/SharePoolingMessageRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\SharePooling\Repositories;
+
+interface SharePoolingMessageRepository
+{
+}

--- a/domain/src/SharePooling/Repositories/SharePoolingRepository.php
+++ b/domain/src/SharePooling/Repositories/SharePoolingRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\SharePooling\Repositories;
+
+use Domain\SharePooling\SharePooling;
+use Domain\SharePooling\SharePoolingId;
+
+interface SharePoolingRepository
+{
+    public function get(SharePoolingId $sharePoolingId): SharePooling;
+}

--- a/domain/src/SharePooling/SharePoolingId.php
+++ b/domain/src/SharePooling/SharePoolingId.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Domain\SharePooling;
 
 use Domain\AggregateRootId;
+use Ramsey\Uuid\Uuid;
 
 final class SharePoolingId extends AggregateRootId
 {
+    private const NAMESPACE = '94ff3977-46f5-4efe-8a89-e474d375232f';
+
+    public static function fromTokenSymbol(string $tokenSymbol): static
+    {
+        return self::fromString(Uuid::uuid5(self::NAMESPACE, trim(strtoupper($tokenSymbol)))->toString());
+    }
 }

--- a/domain/src/SharePooling/ValueObjects/QuantityBreakdown.php
+++ b/domain/src/SharePooling/ValueObjects/QuantityBreakdown.php
@@ -6,8 +6,9 @@ namespace Domain\SharePooling\ValueObjects;
 
 use Domain\SharePooling\ValueObjects\Exceptions\QuantityBreakdownException;
 use Domain\ValueObjects\Quantity;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class QuantityBreakdown
+final class QuantityBreakdown implements SerializablePayload
 {
     private Quantity $quantity;
 
@@ -66,5 +67,21 @@ final class QuantityBreakdown
     public function positions(): array
     {
         return array_keys($this->breakdown);
+    }
+
+    /** @return array<string, array<string>> */
+    public function toPayload(): array
+    {
+        return [
+            'breakdown' => array_map(fn (Quantity $quantity) => $quantity->__toString(), $this->breakdown),
+        ];
+    }
+
+    /** @param array<string, array<string>> $payload */
+    public static function fromPayload(array $payload): static
+    {
+        return new self(
+            breakdown: array_map(fn (string $quantity) => new Quantity($quantity), $payload['breakdown']),
+        );
     }
 }

--- a/domain/src/ValueObjects/FiatAmount.php
+++ b/domain/src/ValueObjects/FiatAmount.php
@@ -7,11 +7,10 @@ namespace Domain\ValueObjects;
 use Domain\Enums\FiatCurrency;
 use Domain\Services\Math;
 use Domain\ValueObjects\Exceptions\FiatAmountException;
-use Illuminate\Contracts\Support\Arrayable;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
 use Stringable;
 
-/** @implements Arrayable<string, string|array<string, string>> */
-final class FiatAmount implements Arrayable, Stringable
+final class FiatAmount implements SerializablePayload, Stringable
 {
     public function __construct(
         public readonly string $amount,
@@ -100,7 +99,7 @@ final class FiatAmount implements Arrayable, Stringable
     }
 
     /** @return array<string, string> */
-    public function toArray(): array
+    public function toPayload(): array
     {
         return [
             'amount' => $this->amount,
@@ -108,12 +107,12 @@ final class FiatAmount implements Arrayable, Stringable
         ];
     }
 
-    /** @param array<string, string> $attributes */
-    public static function fromArray(array $attributes): FiatAmount
+    /** @param array<string, string> $payload */
+    public static function fromPayload(array $payload): static
     {
         return new self(
-            amount: $attributes['amount'],
-            currency: FiatCurrency::from($attributes['currency']),
+            amount: $payload['amount'],
+            currency: FiatCurrency::from($payload['currency']),
         );
     }
 

--- a/domain/tests/SharePooling/Reactors/SharePoolingReactorTestCase.php
+++ b/domain/tests/SharePooling/Reactors/SharePoolingReactorTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Domain\Tests\SharePooling\Reactors;
+
+use Domain\SharePooling\Reactors\SharePoolingReactor;
+use Domain\SharePooling\SharePoolingId;
+use Domain\TaxYear\Repositories\TaxYearRepository;
+use EventSauce\EventSourcing\MessageConsumer;
+use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class SharePoolingReactorTestCase extends MessageConsumerTestCase
+{
+    protected $aggregateRootId;
+    protected MockInterface $taxYearRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->aggregateRootId = SharePoolingId::generate();
+    }
+
+    public function messageConsumer(): MessageConsumer
+    {
+        $this->taxYearRepository = Mockery::mock(TaxYearRepository::class);
+
+        return new SharePoolingReactor($this->taxYearRepository);
+    }
+}


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR introduces the `SharePoolingReactor` reactor.

## Explanation <!-- deeper explanation to guide reviewers -->

This reactor listens to `SharePoolingTokenDisposedOf` and `SharePoolingTokenDisposalReverted` events. When such events occur, it retrieves/creates the relevant `TaxYear` aggregate and asks it to record a capital gain or loss, or to revert one, respectively. It determines whether it's a gain or loss based on the event's attributes.

Repository interfaces have been added to the `SharePooling` domain:

* `SharePoolingRepository`
* `SharePoolingMessageRepository`

The concrete implementations of these classes were added to the `app/` folder, and are extending EventSauce classes.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
