### PR TITLE
Tax year summary projector

### DIFF
--- a/app/TaxYear/TaxYearSummaryRepository.php
+++ b/app/TaxYear/TaxYearSummaryRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TaxYear;
+
+use Domain\TaxYear\Projections\TaxYearSummary;
+use Domain\TaxYear\Repositories\TaxYearSummaryRepository as TaxYearSummaryRepositoryInterface;
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+class TaxYearSummaryRepository implements TaxYearSummaryRepositoryInterface
+{
+    public function recordCapitalGain(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->increaseCapitalGain($amount)
+            ->save();
+    }
+
+    public function revertCapitalGain(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->decreaseCapitalGain($amount)
+            ->save();
+    }
+
+    public function recordCapitalLoss(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->decreaseCapitalGain($amount)
+            ->save();
+    }
+
+    public function revertCapitalLoss(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->increaseCapitalGain($amount)
+            ->save();
+    }
+
+    public function recordIncome(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->increaseIncome($amount)
+            ->save();
+    }
+
+    public function recordNonAttributableAllowableCost(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void
+    {
+        $this->fetchTaxYearSummary($taxYearId, $taxYear, $amount)
+            ->increaseNonAttributableAllowableCosts($amount)
+            ->save();
+    }
+
+    private function fetchTaxYearSummary(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): TaxYearSummary
+    {
+        return TaxYearSummary::firstOrNew(
+            ['tax_year_id' => $taxYearId->toString(), 'currency' => $amount->currency],
+            ['tax_year' => $taxYear],
+        );
+    }
+}

--- a/config/eventsourcing.php
+++ b/config/eventsourcing.php
@@ -12,6 +12,14 @@ use Domain\SharePooling\Events\SharePoolingTokenDisposalReverted;
 use Domain\SharePooling\Events\SharePoolingTokenDisposedOf;
 use Domain\SharePooling\SharePooling;
 use Domain\SharePooling\SharePoolingId;
+use Domain\TaxYear\Events\CapitalGainRecorded;
+use Domain\TaxYear\Events\CapitalGainReverted;
+use Domain\TaxYear\Events\CapitalLossRecorded;
+use Domain\TaxYear\Events\CapitalLossReverted;
+use Domain\TaxYear\Events\IncomeRecorded;
+use Domain\TaxYear\Events\NonAttributableAllowableCostRecorded;
+use Domain\TaxYear\TaxYear;
+use Domain\TaxYear\TaxYearId;
 
 return [
     'class_map' => [
@@ -25,5 +33,13 @@ return [
         SharePoolingTokenAcquired::class => 'share_pooling.share_pooling_acquired',
         SharePoolingTokenDisposalReverted::class => 'share_pooling.share_pooling_disposal_reverted',
         SharePoolingTokenDisposedOf::class => 'share_pooling.share_pooling_disposed_of',
+        TaxYear::class => 'tax_year.tax_year',
+        TaxYearId::class => 'tax_year.tax_year_id',
+        CapitalGainRecorded::class => 'tax_year.capital_gain_recorded',
+        CapitalGainReverted::class => 'tax_year.capital_gain_reverted',
+        CapitalLossRecorded::class => 'tax_year.capital_loss_recorded',
+        CapitalLossReverted::class => 'tax_year.capital_loss_reverted',
+        IncomeRecorded::class => 'tax_year.income_recorded',
+        NonAttributableAllowableCostRecorded::class => 'tax_year.non_attributable_allowable_cost_recorded',
     ],
 ];

--- a/database/migrations/2022_11_26_170325_create_tax_year_events_table.php
+++ b/database/migrations/2022_11_26_170325_create_tax_year_events_table.php
@@ -13,6 +13,7 @@ return new class () extends Migration {
     public function up()
     {
         Schema::create('tax_year_events', function (Blueprint $table) {
+            $table->id()->unsigned();
             $table->uuid('event_id');
             $table->uuid('aggregate_root_id');
             $table->unsignedInteger('version')->nullable();

--- a/database/migrations/2022_11_27_122348_create_share_pooling_events_table.php
+++ b/database/migrations/2022_11_27_122348_create_share_pooling_events_table.php
@@ -13,6 +13,7 @@ return new class () extends Migration {
     public function up()
     {
         Schema::create('share_pooling_events', function (Blueprint $table) {
+            $table->id()->unsigned();
             $table->uuid('event_id');
             $table->uuid('aggregate_root_id');
             $table->unsignedInteger('version')->nullable();

--- a/database/migrations/2022_12_02_113852_create_tax_year_summaries_table.php
+++ b/database/migrations/2022_12_02_113852_create_tax_year_summaries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tax_year_summaries', function (Blueprint $table) {
+            $table->uuid('tax_year_id')->primary();
+            $table->string('tax_year', 9);
+            $table->string('currency', 3);
+            $table->string('capital_gain')->default('0');
+            $table->string('income')->default('0');
+            $table->string('non_attributable_allowable_costs')->default('0');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tax_year_summaries');
+    }
+};

--- a/domain/src/TaxYear/Actions/RecordCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalGain.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RecordCapitalGain
+final class RecordCapitalGain extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/RecordCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RecordCapitalLoss.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RecordCapitalLoss
+final class RecordCapitalLoss extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/RecordIncome.php
+++ b/domain/src/TaxYear/Actions/RecordIncome.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RecordIncome
+final class RecordIncome extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
+++ b/domain/src/TaxYear/Actions/RecordNonAttributableAllowableCost.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RecordNonAttributableAllowableCost
+final class RecordNonAttributableAllowableCost extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/RevertCapitalGain.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalGain.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RevertCapitalGain
+final class RevertCapitalGain extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/RevertCapitalLoss.php
+++ b/domain/src/TaxYear/Actions/RevertCapitalLoss.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Actions;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class RevertCapitalLoss
+final class RevertCapitalLoss extends TaxYearAction
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Actions/TaxYearAction.php
+++ b/domain/src/TaxYear/Actions/TaxYearAction.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Actions;
+
+use Domain\ValueObjects\FiatAmount;
+
+abstract class TaxYearAction
+{
+    final public function __construct(
+        public readonly string $taxYear,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+}

--- a/domain/src/TaxYear/Events/CapitalGainRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalGainRecorded.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class CapitalGainRecorded
+final class CapitalGainRecorded extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/CapitalGainReverted.php
+++ b/domain/src/TaxYear/Events/CapitalGainReverted.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class CapitalGainReverted
+final class CapitalGainReverted extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/CapitalLossRecorded.php
+++ b/domain/src/TaxYear/Events/CapitalLossRecorded.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class CapitalLossRecorded
+final class CapitalLossRecorded extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/CapitalLossReverted.php
+++ b/domain/src/TaxYear/Events/CapitalLossReverted.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class CapitalLossReverted
+final class CapitalLossReverted extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/IncomeRecorded.php
+++ b/domain/src/TaxYear/Events/IncomeRecorded.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class IncomeRecorded
+final class IncomeRecorded extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
+++ b/domain/src/TaxYear/Events/NonAttributableAllowableCostRecorded.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Domain\TaxYear\Events;
 
-use Domain\ValueObjects\FiatAmount;
-
-final class NonAttributableAllowableCostRecorded
+final class NonAttributableAllowableCostRecorded extends TaxYearEvent
 {
-    public function __construct(
-        public readonly FiatAmount $amount,
-    ) {
-    }
 }

--- a/domain/src/TaxYear/Events/TaxYearEvent.php
+++ b/domain/src/TaxYear/Events/TaxYearEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Events;
+
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+
+abstract class TaxYearEvent implements SerializablePayload
+{
+    final public function __construct(
+        public readonly string $taxYear,
+        public readonly FiatAmount $amount,
+    ) {
+    }
+
+    /** @return array<string, string|array<string, string>> */
+    public function toPayload(): array
+    {
+        return [
+            'tax_year' => $this->taxYear,
+            'amount' => $this->amount->toPayload(),
+        ];
+    }
+
+    /** @param array<string, string|array<string, string>> $payload */
+    public static function fromPayload(array $payload): static
+    {
+        return new static(
+            $payload['tax_year'], // @phpstan-ignore-line
+            FiatAmount::fromPayload($payload['amount']), // @phpstan-ignore-line
+        );
+    }
+}

--- a/domain/src/TaxYear/Projections/TaxYearSummary.php
+++ b/domain/src/TaxYear/Projections/TaxYearSummary.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Projections;
+
+use Domain\Enums\FiatCurrency;
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\Exceptions\FiatAmountException;
+use Domain\ValueObjects\FiatAmount;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property TaxYearId $tax_year_id
+ * @property string $tax_year
+ * @property FiatCurrency $currency
+ * @property FiatAmount $capital_gain
+ * @property FiatAmount $income
+ * @property FiatAmount $non_attributable_allowable_costs
+ * @method static self firstOrNew($attributes = [], $values = [])
+ */
+final class TaxYearSummary extends Model
+{
+    /** The primary key for the model. */
+    protected $primaryKey = 'tax_year_id';
+
+    /** The "type" of the primary key ID. */
+    protected $keyType = 'string';
+
+    /** Indicates if the IDs are auto-incrementing. */
+    public $incrementing = false;
+
+    /** Indicates if the model should be timestamped. */
+    public $timestamps = false;
+
+    /** Indicates if all mass assignment is enabled. */
+    protected static $unguarded = true;
+
+    /** @throws FiatAmountException */
+    public function increaseCapitalGain(FiatAmount $amount): self
+    {
+        $this->capital_gain = $this->capital_gain->plus($amount);
+
+        return $this;
+    }
+
+    /** @throws FiatAmountException */
+    public function decreaseCapitalGain(FiatAmount $amount): self
+    {
+        $this->capital_gain = $this->capital_gain->minus($amount);
+
+        return $this;
+    }
+
+    /** @throws FiatAmountException */
+    public function increaseIncome(FiatAmount $amount): self
+    {
+        $this->income = $this->income->plus($amount);
+
+        return $this;
+    }
+
+    /** @throws FiatAmountException */
+    public function increaseNonAttributableAllowableCosts(FiatAmount $amount): self
+    {
+        $this->non_attributable_allowable_costs = $this->non_attributable_allowable_costs->plus($amount);
+
+        return $this;
+    }
+
+    protected function taxYearId(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => TaxYearId::fromString($value),
+            set: fn ($value) => $value instanceof TaxYearId ? $value->toString() : $value,
+        );
+    }
+
+    protected function currency(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => FiatCurrency::from($value),
+            set: fn (FiatCurrency $value) => $value->value,
+        );
+    }
+
+    protected function capitalGain(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => $value->amount,
+        );
+    }
+
+    protected function income(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => $value->amount,
+        );
+    }
+
+    protected function nonAttributableAllowableCosts(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => $value->amount,
+        );
+    }
+}

--- a/domain/src/TaxYear/Projectors/Exceptions/TaxYearSummaryProjectionException.php
+++ b/domain/src/TaxYear/Projectors/Exceptions/TaxYearSummaryProjectionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Projectors\Exceptions;
+
+use RuntimeException;
+
+final class TaxYearSummaryProjectionException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function missingTaxYearId(string $eventClass): self
+    {
+        return new self(sprintf('Event of type %s was caught without a tax year ID', $eventClass));
+    }
+}

--- a/domain/src/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Projectors;
+
+use Domain\TaxYear\Events\CapitalGainRecorded;
+use Domain\TaxYear\Events\CapitalGainReverted;
+use Domain\TaxYear\Events\CapitalLossRecorded;
+use Domain\TaxYear\Events\CapitalLossReverted;
+use Domain\TaxYear\Events\IncomeRecorded;
+use Domain\TaxYear\Events\NonAttributableAllowableCostRecorded;
+use Domain\TaxYear\Projectors\Exceptions\TaxYearSummaryProjectionException;
+use Domain\TaxYear\Repositories\TaxYearSummaryRepository;
+use Domain\TaxYear\TaxYearId;
+use EventSauce\EventSourcing\EventConsumption\EventConsumer;
+use EventSauce\EventSourcing\Message;
+
+final class TaxYearSummaryProjector extends EventConsumer
+{
+    public function __construct(private TaxYearSummaryRepository $taxYearSummaryRepository)
+    {
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleCapitalGainRecorded(CapitalGainRecorded $event, Message $message): void
+    {
+        $this->taxYearSummaryRepository->recordCapitalGain($this->getTaxYearId($message), $event->amount);
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleCapitalGainReverted(CapitalGainReverted $event, Message $message): void
+    {
+        $this->taxYearSummaryRepository->revertCapitalGain($this->getTaxYearId($message), $event->amount);
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleCapitalLossRecorded(CapitalLossRecorded $event, Message $message): void
+    {
+        $this->taxYearSummaryRepository->recordCapitalLoss($this->getTaxYearId($message), $event->amount);
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleCapitalLossReverted(CapitalLossReverted $event, Message $message): void
+    {
+        $this->taxYearSummaryRepository->revertCapitalLoss($this->getTaxYearId($message), $event->amount);
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleIncomeRecorded(IncomeRecorded $event, Message $message): void
+    {
+        $this->taxYearSummaryRepository->recordIncome($this->getTaxYearId($message), $event->amount);
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    public function handleNonAttributableAllowableCostRecorded(
+        NonAttributableAllowableCostRecorded $event,
+        Message $message,
+    ): void {
+        $this->taxYearSummaryRepository->recordNonAttributableAllowableCost(
+            $this->getTaxYearId($message),
+            $event->amount,
+        );
+    }
+
+    /** @throws TaxYearSummaryProjectionException */
+    private function getTaxYearId(Message $message): TaxYearId
+    {
+        if (is_null($taxYearId = $message->aggregateRootId()?->toString())) {
+            throw TaxYearSummaryProjectionException::missingTaxYearId($message->payload()::class);
+        }
+
+        return TaxYearId::fromString($taxYearId);
+    }
+}

--- a/domain/src/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -25,31 +25,51 @@ final class TaxYearSummaryProjector extends EventConsumer
     /** @throws TaxYearSummaryProjectionException */
     public function handleCapitalGainRecorded(CapitalGainRecorded $event, Message $message): void
     {
-        $this->taxYearSummaryRepository->recordCapitalGain($this->getTaxYearId($message), $event->amount);
+        $this->taxYearSummaryRepository->recordCapitalGain(
+            $this->getTaxYearId($message),
+            $event->taxYear,
+            $event->amount,
+        );
     }
 
     /** @throws TaxYearSummaryProjectionException */
     public function handleCapitalGainReverted(CapitalGainReverted $event, Message $message): void
     {
-        $this->taxYearSummaryRepository->revertCapitalGain($this->getTaxYearId($message), $event->amount);
+        $this->taxYearSummaryRepository->revertCapitalGain(
+            $this->getTaxYearId($message),
+            $event->taxYear,
+            $event->amount,
+        );
     }
 
     /** @throws TaxYearSummaryProjectionException */
     public function handleCapitalLossRecorded(CapitalLossRecorded $event, Message $message): void
     {
-        $this->taxYearSummaryRepository->recordCapitalLoss($this->getTaxYearId($message), $event->amount);
+        $this->taxYearSummaryRepository->recordCapitalLoss(
+            $this->getTaxYearId($message),
+            $event->taxYear,
+            $event->amount,
+        );
     }
 
     /** @throws TaxYearSummaryProjectionException */
     public function handleCapitalLossReverted(CapitalLossReverted $event, Message $message): void
     {
-        $this->taxYearSummaryRepository->revertCapitalLoss($this->getTaxYearId($message), $event->amount);
+        $this->taxYearSummaryRepository->revertCapitalLoss(
+            $this->getTaxYearId($message),
+            $event->taxYear,
+            $event->amount,
+        );
     }
 
     /** @throws TaxYearSummaryProjectionException */
     public function handleIncomeRecorded(IncomeRecorded $event, Message $message): void
     {
-        $this->taxYearSummaryRepository->recordIncome($this->getTaxYearId($message), $event->amount);
+        $this->taxYearSummaryRepository->recordIncome(
+            $this->getTaxYearId($message),
+            $event->taxYear,
+            $event->amount,
+        );
     }
 
     /** @throws TaxYearSummaryProjectionException */
@@ -59,6 +79,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     ): void {
         $this->taxYearSummaryRepository->recordNonAttributableAllowableCost(
             $this->getTaxYearId($message),
+            $event->taxYear,
             $event->amount,
         );
     }

--- a/domain/src/TaxYear/Repositories/TaxYearSummaryRepository.php
+++ b/domain/src/TaxYear/Repositories/TaxYearSummaryRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Repositories;
+
+use Domain\TaxYear\TaxYearId;
+use Domain\ValueObjects\FiatAmount;
+
+interface TaxYearSummaryRepository
+{
+    public function recordCapitalGain(TaxYearId $taxYearId, FiatAmount $amount): void;
+
+    public function revertCapitalGain(TaxYearId $taxYearId, FiatAmount $amount): void;
+
+    public function recordCapitalLoss(TaxYearId $taxYearId, FiatAmount $amount): void;
+
+    public function revertCapitalLoss(TaxYearId $taxYearId, FiatAmount $amount): void;
+
+    public function recordIncome(TaxYearId $taxYearId, FiatAmount $amount): void;
+
+    public function recordNonAttributableAllowableCost(TaxYearId $taxYearId, FiatAmount $amount): void;
+}

--- a/domain/src/TaxYear/Repositories/TaxYearSummaryRepository.php
+++ b/domain/src/TaxYear/Repositories/TaxYearSummaryRepository.php
@@ -9,15 +9,15 @@ use Domain\ValueObjects\FiatAmount;
 
 interface TaxYearSummaryRepository
 {
-    public function recordCapitalGain(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function recordCapitalGain(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 
-    public function revertCapitalGain(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function revertCapitalGain(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 
-    public function recordCapitalLoss(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function recordCapitalLoss(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 
-    public function revertCapitalLoss(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function revertCapitalLoss(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 
-    public function recordIncome(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function recordIncome(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 
-    public function recordNonAttributableAllowableCost(TaxYearId $taxYearId, FiatAmount $amount): void;
+    public function recordNonAttributableAllowableCost(TaxYearId $taxYearId, string $taxYear, FiatAmount $amount): void;
 }

--- a/domain/src/TaxYear/Services/TaxYearGenerator.php
+++ b/domain/src/TaxYear/Services/TaxYearGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\TaxYear\Services;
+
+final class TaxYearGenerator
+{
+    public static function fromYear(int $year): string
+    {
+        return sprintf('%s-%s', $year, $year + 1);
+    }
+}

--- a/domain/src/TaxYear/TaxYear.php
+++ b/domain/src/TaxYear/TaxYear.php
@@ -48,7 +48,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new CapitalGainRecorded(amount: $action->amount));
+        $this->recordThat(new CapitalGainRecorded(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyCapitalGainRecorded(CapitalGainRecorded $event): void
@@ -71,7 +74,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new CapitalGainReverted(amount: $action->amount));
+        $this->recordThat(new CapitalGainReverted(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyCapitalGainReverted(CapitalGainReverted $event): void
@@ -91,7 +97,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new CapitalLossRecorded(amount: $action->amount));
+        $this->recordThat(new CapitalLossRecorded(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyCapitalLossRecorded(CapitalLossRecorded $event): void
@@ -115,7 +124,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new CapitalLossReverted(amount: $action->amount));
+        $this->recordThat(new CapitalLossReverted(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyCapitalLossReverted(CapitalLossReverted $event): void
@@ -135,7 +147,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new IncomeRecorded(amount: $action->amount));
+        $this->recordThat(new IncomeRecorded(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyIncomeRecorded(IncomeRecorded $event): void
@@ -154,7 +169,10 @@ class TaxYear implements AggregateRoot
             );
         }
 
-        $this->recordThat(new NonAttributableAllowableCostRecorded(amount: $action->amount));
+        $this->recordThat(new NonAttributableAllowableCostRecorded(
+            taxYear: $action->taxYear,
+            amount: $action->amount,
+        ));
     }
 
     public function applyNonAttributableAllowableCostRecorded(NonAttributableAllowableCostRecorded $event): void

--- a/domain/src/TaxYear/TaxYearId.php
+++ b/domain/src/TaxYear/TaxYearId.php
@@ -11,10 +11,8 @@ final class TaxYearId extends AggregateRootId
 {
     private const NAMESPACE = '4c6f1e6b-b69c-4b01-8200-3a73dd49cc9c';
 
-    public static function fromYear(int $year): static
+    public static function fromTaxYear(string $taxYear): static
     {
-        $taxYear = sprintf('%s-%s', $year, $year + 1);
-
         return self::fromString(Uuid::uuid5(self::NAMESPACE, $taxYear)->toString());
     }
 }

--- a/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Domain\Enums\FiatCurrency;
+use Domain\TaxYear\Events\CapitalGainRecorded;
+use Domain\TaxYear\Events\CapitalGainReverted;
+use Domain\TaxYear\Events\CapitalLossRecorded;
+use Domain\TaxYear\Events\CapitalLossReverted;
+use Domain\TaxYear\Events\IncomeRecorded;
+use Domain\TaxYear\Events\NonAttributableAllowableCostRecorded;
+use Domain\Tests\TaxYear\Projectors\TaxYearSummaryProjectorTestCase;
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
+
+uses(TaxYearSummaryProjectorTestCase::class);
+
+it('can handle a capital gain', function () {
+    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($capitalGainRecorded))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalGain')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalGainRecorded) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $capitalGainRecorded->amount;
+            }));
+});
+
+it('can handle a capital gain reversion', function () {
+    $capitalGainReverted = new CapitalGainReverted(amount: new FiatAmount('100', FiatCurrency::GBP));
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($capitalGainReverted))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalGain')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalGainReverted) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $capitalGainReverted->amount;
+            }));
+});
+
+it('can handle a capital loss', function () {
+    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($capitalLossRecorded))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalLoss')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalLossRecorded) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $capitalLossRecorded->amount;
+            }));
+});
+
+it('can handle a capital loss reversion', function () {
+    $capitalLossReverted = new CapitalLossReverted(amount: new FiatAmount('100', FiatCurrency::GBP));
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($capitalLossReverted))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalLoss')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalLossReverted) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $capitalLossReverted->amount;
+            }));
+});
+
+it('can handle some income', function () {
+    $incomeRecorded = new IncomeRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($incomeRecorded))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordIncome')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($incomeRecorded) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $incomeRecorded->amount;
+            }));
+});
+
+it('can handle a non-attributable allowable cost', function () {
+    $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    /** @var MessageConsumerTestCase $this */
+    $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
+        ->when(new Message($nonAttributableAllowableCostRecorded))
+        ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordNonAttributableAllowableCost')
+            ->once()
+            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($nonAttributableAllowableCostRecorded) {
+                return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $amount === $nonAttributableAllowableCostRecorded->amount;
+            }));
+});

--- a/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -16,77 +16,98 @@ use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
 uses(TaxYearSummaryProjectorTestCase::class);
 
 it('can handle a capital gain', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
 
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalGainRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalGain')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalGainRecorded) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalGainRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $capitalGainRecorded->amount;
             }));
 });
 
 it('can handle a capital gain reversion', function () {
-    $capitalGainReverted = new CapitalGainReverted(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalGainReverted = new CapitalGainReverted(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
 
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalGainReverted))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalGain')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalGainReverted) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalGainReverted) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $capitalGainReverted->amount;
             }));
 });
 
 it('can handle a capital loss', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalLossRecorded = new CapitalLossRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
 
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalLossRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalLoss')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalLossRecorded) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalLossRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $capitalLossRecorded->amount;
             }));
 });
 
 it('can handle a capital loss reversion', function () {
-    $capitalLossReverted = new CapitalLossReverted(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $capitalLossReverted = new CapitalLossReverted(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
 
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalLossReverted))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalLoss')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($capitalLossReverted) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalLossReverted) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $capitalLossReverted->amount;
             }));
 });
 
 it('can handle some income', function () {
-    $incomeRecorded = new IncomeRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
+    $incomeRecorded = new IncomeRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
 
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($incomeRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordIncome')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($incomeRecorded) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($incomeRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $incomeRecorded->amount;
             }));
 });
 
 it('can handle a non-attributable allowable cost', function () {
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
+        taxYear: $this->taxYear,
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -95,8 +116,9 @@ it('can handle a non-attributable allowable cost', function () {
         ->when(new Message($nonAttributableAllowableCostRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordNonAttributableAllowableCost')
             ->once()
-            ->withArgs(function (AggregateRootId $taxYearId, FiatAmount $amount) use ($nonAttributableAllowableCostRecorded) {
+            ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($nonAttributableAllowableCostRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
+                    && $taxYear === $this->taxYear
                     && $amount === $nonAttributableAllowableCostRecorded->amount;
             }));
 });

--- a/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTestCase.php
+++ b/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTestCase.php
@@ -12,6 +12,8 @@ use Mockery\MockInterface;
 
 class TaxYearSummaryProjectorTestCase extends MessageConsumerTestCase
 {
+    protected string $taxYear = '2015-2016';
+
     protected $aggregateRootId;
     protected MockInterface $taxYearSummaryRepository;
 

--- a/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTestCase.php
+++ b/domain/tests/TaxYear/Projectors/TaxYearSummaryProjectorTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Domain\Tests\TaxYear\Projectors;
+
+use Domain\TaxYear\Projectors\TaxYearSummaryProjector;
+use Domain\TaxYear\Repositories\TaxYearSummaryRepository;
+use Domain\TaxYear\TaxYearId;
+use EventSauce\EventSourcing\MessageConsumer;
+use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class TaxYearSummaryProjectorTestCase extends MessageConsumerTestCase
+{
+    protected $aggregateRootId;
+    protected MockInterface $taxYearSummaryRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->aggregateRootId = TaxYearId::generate();
+    }
+
+    public function messageConsumer(): MessageConsumer
+    {
+        $this->taxYearSummaryRepository = Mockery::spy(TaxYearSummaryRepository::class);
+
+        return new TaxYearSummaryProjector($this->taxYearSummaryRepository);
+    }
+}

--- a/domain/tests/TaxYear/TaxYearTest.php
+++ b/domain/tests/TaxYear/TaxYearTest.php
@@ -21,8 +21,15 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 uses(TaxYearTestCase::class);
 
 it('can record a capital gain', function () {
-    $recordCapitalGain = new RecordCapitalGain(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $capitalGainRecorded = new CapitalGainRecorded(amount: $recordCapitalGain->amount);
+    $recordCapitalGain = new RecordCapitalGain(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYear: $this->taxYear,
+        amount: $recordCapitalGain->amount,
+    );
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordCapitalGain)
@@ -30,8 +37,15 @@ it('can record a capital gain', function () {
 });
 
 it('cannot record a capital gain because the currency is different', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $recordCapitalGain = new RecordCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $recordCapitalGain = new RecordCapitalGain(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
 
     $cannotRecordCapitalGain = TaxYearException::cannotRecordCapitalGainForDifferentCurrency(
         taxYearId: $this->aggregateRootId,
@@ -46,9 +60,20 @@ it('cannot record a capital gain because the currency is different', function ()
 });
 
 it('can revert a capital gain', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $capitalGainReverted = new CapitalGainReverted(amount: $revertCapitalGain->amount);
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalGainReverted = new CapitalGainReverted(
+        taxYear: $this->taxYear,
+        amount: $revertCapitalGain->amount,
+    );
 
     /** @var AggregateRootTestCase $this */
     $this->given($capitalGainRecorded)
@@ -57,7 +82,11 @@ it('can revert a capital gain', function () {
 });
 
 it('cannot revert a capital gain before a capital gain was recorded', function () {
-    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
     $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainBeforeCapitalGainIsRecorded(
         taxYearId: $this->aggregateRootId,
     );
@@ -68,8 +97,15 @@ it('cannot revert a capital gain before a capital gain was recorded', function (
 });
 
 it('cannot revert a capital gain because the currency is different', function () {
-    $capitalGainRecorded = new CapitalGainRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $revertCapitalGain = new RevertCapitalGain(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $capitalGainRecorded = new CapitalGainRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalGain = new RevertCapitalGain(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
 
     $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainFromDifferentCurrency(
         taxYearId: $this->aggregateRootId,
@@ -84,8 +120,15 @@ it('cannot revert a capital gain because the currency is different', function ()
 });
 
 it('can record a capital loss', function () {
-    $recordCapitalLoss = new RecordCapitalLoss(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $capitalLossRecorded = new CapitalLossRecorded(amount: $recordCapitalLoss->amount);
+    $recordCapitalLoss = new RecordCapitalLoss(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalLossRecorded = new CapitalLossRecorded(
+        taxYear: $this->taxYear,
+        amount: $recordCapitalLoss->amount,
+    );
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordCapitalLoss)
@@ -93,8 +136,15 @@ it('can record a capital loss', function () {
 });
 
 it('cannot record a capital loss because the currency is different', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $recordCapitalLoss = new RecordCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $capitalLossRecorded = new CapitalLossRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $recordCapitalLoss = new RecordCapitalLoss(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
 
     $cannotRecordCapitalLoss = TaxYearException::cannotRecordCapitalLossForDifferentCurrency(
         taxYearId: $this->aggregateRootId,
@@ -109,9 +159,20 @@ it('cannot record a capital loss because the currency is different', function ()
 });
 
 it('can revert a capital loss', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $capitalLossReverted = new CapitalLossReverted(amount: $revertCapitalLoss->amount);
+    $capitalLossRecorded = new CapitalLossRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalLoss = new RevertCapitalLoss(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $capitalLossReverted = new CapitalLossReverted(
+        taxYear: $this->taxYear,
+        amount: $revertCapitalLoss->amount,
+    );
 
     /** @var AggregateRootTestCase $this */
     $this->given($capitalLossRecorded)
@@ -120,7 +181,11 @@ it('can revert a capital loss', function () {
 });
 
 it('cannot revert a capital loss before a capital loss was recorded', function () {
-    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $revertCapitalLoss = new RevertCapitalLoss(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
     $cannotRevertCapitalLoss = TaxYearException::cannotRevertCapitalLossBeforeCapitalLossIsRecorded(
         taxYearId: $this->aggregateRootId,
     );
@@ -131,8 +196,15 @@ it('cannot revert a capital loss before a capital loss was recorded', function (
 });
 
 it('cannot revert a capital loss because the currency is different', function () {
-    $capitalLossRecorded = new CapitalLossRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $revertCapitalLoss = new RevertCapitalLoss(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $capitalLossRecorded = new CapitalLossRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $revertCapitalLoss = new RevertCapitalLoss(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
 
     $cannotRevertCapitalLoss = TaxYearException::cannotRevertCapitalLossFromDifferentCurrency(
         taxYearId: $this->aggregateRootId,
@@ -147,8 +219,15 @@ it('cannot revert a capital loss because the currency is different', function ()
 });
 
 it('can record some income', function () {
-    $recordIncome = new RecordIncome(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $incomeRecorded = new IncomeRecorded(amount: $recordIncome->amount);
+    $recordIncome = new RecordIncome(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $incomeRecorded = new IncomeRecorded(
+        taxYear: $this->taxYear,
+        amount: $recordIncome->amount,
+    );
 
     /** @var AggregateRootTestCase $this */
     $this->when($recordIncome)
@@ -156,8 +235,15 @@ it('can record some income', function () {
 });
 
 it('cannot record some income because the currency is different', function () {
-    $incomeRecorded = new IncomeRecorded(amount: new FiatAmount('100', FiatCurrency::GBP));
-    $recordIncome = new RecordIncome(amount: new FiatAmount('100', FiatCurrency::EUR));
+    $incomeRecorded = new IncomeRecorded(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::GBP),
+    );
+
+    $recordIncome = new RecordIncome(
+        taxYear: $this->taxYear,
+        amount: new FiatAmount('100', FiatCurrency::EUR),
+    );
 
     $cannotRecordIncome = TaxYearException::cannotRecordIncomeFromDifferentCurrency(
         taxYearId: $this->aggregateRootId,
@@ -173,10 +259,12 @@ it('cannot record some income because the currency is different', function () {
 
 it('can record a non-attributable allowable cost', function () {
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
+        taxYear: $this->taxYear,
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
+        taxYear: $this->taxYear,
         amount: $recordNonAttributableAllowableCost->amount,
     );
 
@@ -187,10 +275,12 @@ it('can record a non-attributable allowable cost', function () {
 
 it('cannot record a non-attributable allowable cost because the currency is different', function () {
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
+        taxYear: $this->taxYear,
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
+        taxYear: $this->taxYear,
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 

--- a/domain/tests/TaxYear/TaxYearTestCase.php
+++ b/domain/tests/TaxYear/TaxYearTestCase.php
@@ -15,6 +15,8 @@ use EventSauce\EventSourcing\AggregateRootId;
 
 abstract class TaxYearTestCase extends AggregateRootTestCase
 {
+    protected string $taxYear = '2015-2016';
+
     protected function newAggregateRootId(): AggregateRootId
     {
         return TaxYearId::generate();


### PR DESCRIPTION
## Summary

This PR introduces the `TaxYearSummary` projector and projection.

## Explanation

The projector reacts to the following events:

* `CapitalGainRecorded`;
* `CapitalGainReverted`;
* `CapitalLossRecorded`;
* `CapitalLossReverted`;
* `IncomeRecorded`; and
* `NonAttributableAllowableCostRecorded`.

For each of these events, it updates the relevant `TaxYearSummary` projection through the new `TaxYearSummaryRepository` repository.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
