### PR TITLE
Income handler

### DIFF
--- a/domain/src/Enums/Operation.php
+++ b/domain/src/Enums/Operation.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Enums;
+
+enum Operation: string
+{
+    case Receive = 'receive';
+    case Send = 'send';
+    case Swap = 'swap';
+    case Transfer = 'transfer';
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/IncomeHandlerException.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/IncomeHandlerException.php
@@ -14,8 +14,8 @@ final class IncomeHandlerException extends RuntimeException
         parent::__construct($message);
     }
 
-    public static function invalidTransaction(Transaction $transaction): self
+    public static function invalidTransaction(string $error, Transaction $transaction): self
     {
-        return new self($transaction->__toString());
+        return new self(sprintf('Invalid transaction: %s. Transaction: %s', $error, $transaction->__toString()));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/IncomeHandlerException.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/IncomeHandlerException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers\Exceptions;
+
+use Domain\ValueObjects\Transaction;
+use RuntimeException;
+
+final class IncomeHandlerException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidTransaction(Transaction $transaction): self
+    {
+        return new self($transaction->__toString());
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers;
+
+use Domain\Aggregates\TaxYear\Actions\RecordIncome;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
+use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\TaxYearId;
+use Domain\Enums\Operation;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\IncomeHandlerException;
+use Domain\ValueObjects\Transaction;
+
+class IncomeHandler
+{
+    public function __construct(private TaxYearRepository $taxYearRepository)
+    {
+    }
+
+    /** @throws IncomeHandlerException */
+    public function handle(Transaction $transaction): void
+    {
+        $this->validate($transaction);
+
+        $taxYear = TaxYearGenerator::fromYear($transaction->date->getYear());
+        $taxYearId = TaxYearId::fromTaxYear($taxYear);
+        $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
+
+        $taxYearAggregate->recordIncome(new RecordIncome(taxYear: $taxYear, amount: $transaction->costBasis));
+    }
+
+    /** @throws IncomeHandlerException */
+    private function validate(Transaction $transaction): void
+    {
+        if ($transaction->operation !== Operation::Receive) {
+            throw IncomeHandlerException::invalidTransaction($transaction);
+        }
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -32,6 +32,7 @@ class IncomeHandler
     /** @throws IncomeHandlerException */
     private function validate(Transaction $transaction): void
     {
-        $transaction->isReceive() || throw IncomeHandlerException::invalidTransaction($transaction);
+        $transaction->isReceive() || throw IncomeHandlerException::invalidTransaction('not receive', $transaction);
+        $transaction->isIncome || throw IncomeHandlerException::invalidTransaction('not income', $transaction);
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -8,7 +8,6 @@ use Domain\Aggregates\TaxYear\Actions\RecordIncome;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
 use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
 use Domain\Aggregates\TaxYear\TaxYearId;
-use Domain\Enums\Operation;
 use Domain\Services\TransactionDispatcher\Handlers\Exceptions\IncomeHandlerException;
 use Domain\ValueObjects\Transaction;
 
@@ -33,8 +32,6 @@ class IncomeHandler
     /** @throws IncomeHandlerException */
     private function validate(Transaction $transaction): void
     {
-        if ($transaction->operation !== Operation::Receive) {
-            throw IncomeHandlerException::invalidTransaction($transaction);
-        }
+        $transaction->isReceive() || throw IncomeHandlerException::invalidTransaction($transaction);
     }
 }

--- a/domain/src/ValueObjects/Exceptions/TransactionException.php
+++ b/domain/src/ValueObjects/Exceptions/TransactionException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\ValueObjects\Exceptions;
+
+use Domain\ValueObjects\Transaction;
+use RuntimeException;
+
+final class TransactionException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidData(string $error, Transaction $transaction): self
+    {
+        return new self(sprintf('Invalid transaction data: %s. Transaction: %s', $error, $transaction->__toString()));
+    }
+}

--- a/domain/src/ValueObjects/Transaction.php
+++ b/domain/src/ValueObjects/Transaction.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\ValueObjects;
+
+use Brick\DateTime\LocalDate;
+use Domain\Enums\Operation;
+use Domain\Tests\Factories\ValueObjects\TransactionFactory;
+use Domain\ValueObjects\Exceptions\TransactionException;
+use Domain\ValueObjects\FiatAmount;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Stringable;
+
+final class Transaction implements Stringable
+{
+    use HasFactory;
+
+    /** @throws TransactionException */
+    public function __construct(
+        public readonly LocalDate $date,
+        public readonly Operation $operation,
+        public readonly bool $isIncome,
+        public readonly FiatAmount $costBasis,
+        public readonly ?string $sentAsset,
+        public readonly Quantity $sentQuantity,
+        public readonly bool $sentAssetIsNft,
+        public readonly ?string $receivedAsset,
+        public readonly Quantity $receivedQuantity,
+        public readonly bool $receivedAssetIsNft,
+        public readonly ?string $transactionFeeCurrency,
+        public readonly Quantity $transactionFeeQuantity,
+        public readonly ?string $exchangeFeeCurrency,
+        public readonly Quantity $exchangeFeeQuantity,
+    ) {
+        match ($operation) {
+            Operation::Receive => $this->validateReceive($sentAsset, $receivedAsset, $receivedQuantity),
+        };
+    }
+
+    /** @return TransactionFactory<static> */
+    protected static function newFactory(): TransactionFactory
+    {
+        return TransactionFactory::new();
+    }
+
+    /** @throws TransactionException */
+    private function validateReceive(?string $sentAsset, ?string $receivedAsset, Quantity $receivedQuantity): void
+    {
+        $error = 'Receive operations should %s';
+
+        if (! is_null($sentAsset)) {
+            throw TransactionException::invalidData(sprintf($error, 'not have a sent asset'), $this);
+        }
+
+        if (is_null($receivedAsset)) {
+            throw TransactionException::invalidData(sprintf($error, 'have a received asset'), $this);
+        }
+
+        if ($receivedQuantity->isLessThanOrEqualTo('0')) {
+            throw TransactionException::invalidData(sprintf($error, 'have a received quantity greater than zero'), $this);
+        }
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '%s | %s | income: %s | cost basis: %s | sent: %s | quantity: %s | NFT: %s | received: %s | quantity: %s | NFT: %s | Tx fee: %s | quantity: %s | Cex fee: %s | quantity: %s',
+            $this->date->__toString(),
+            $this->operation->value,
+            $this->isIncome ? 'yes' : 'no',
+            $this->costBasis->__toString(),
+            $this->sentAsset,
+            $this->sentQuantity->__toString(),
+            $this->sentAssetIsNft ? 'yes' : 'no',
+            $this->receivedAsset,
+            $this->receivedQuantity->__toString(),
+            $this->receivedAssetIsNft ? 'yes' : 'no',
+            $this->transactionFeeCurrency,
+            $this->transactionFeeQuantity->__toString(),
+            $this->exchangeFeeCurrency,
+            $this->exchangeFeeQuantity->__toString(),
+        );
+    }
+}

--- a/domain/src/ValueObjects/Transaction.php
+++ b/domain/src/ValueObjects/Transaction.php
@@ -8,7 +8,6 @@ use Brick\DateTime\LocalDate;
 use Domain\Enums\Operation;
 use Domain\Tests\Factories\ValueObjects\TransactionFactory;
 use Domain\ValueObjects\Exceptions\TransactionException;
-use Domain\ValueObjects\FiatAmount;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Stringable;
 

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -58,4 +58,37 @@ class TransactionFactory extends PlainObjectFactory
             'receivedQuantity' => new Quantity('1'),
         ]);
     }
+
+    public function send(): static
+    {
+        return $this->state([
+            'operation' => Operation::Send,
+            'sentAsset' => 'BTC',
+            'sentQuantity' => new Quantity('1'),
+            'receivedAsset' => null,
+            'receivedQuantity' => Quantity::zero(),
+        ]);
+    }
+
+    public function swap(): static
+    {
+        return $this->state([
+            'operation' => Operation::Send,
+            'sentAsset' => 'BTC',
+            'sentQuantity' => new Quantity('1'),
+            'receivedAsset' => 'ETH',
+            'receivedQuantity' => new Quantity('10'),
+        ]);
+    }
+
+    public function transfer(): static
+    {
+        return $this->state([
+            'operation' => Operation::Send,
+            'sentAsset' => 'BTC',
+            'sentQuantity' => new Quantity('1'),
+            'receivedAsset' => null,
+            'receivedQuantity' => Quantity::zero(),
+        ]);
+    }
 }

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Domain\Tests\Factories\ValueObjects;
+
+use Brick\DateTime\LocalDate;
+use Domain\Enums\FiatCurrency;
+use Domain\Enums\Operation;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Quantity;
+use Domain\ValueObjects\Transaction;
+use Tests\Factories\PlainObjectFactory;
+
+/**
+ * @template TModel of Transaction
+ *
+ * @extends PlainObjectFactory
+ */
+class TransactionFactory extends PlainObjectFactory
+{
+    /** @var string */
+    protected $model = Transaction::class;
+
+    /** @return array */
+    public function definition()
+    {
+        return [
+            'date' => LocalDate::parse('2015-10-21'),
+            'operation' => Operation::Receive,
+            'isIncome' => false,
+            'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
+            'sentAsset' => null,
+            'sentQuantity' => Quantity::zero(),
+            'sentAssetIsNft' => false,
+            'receivedAsset' => 'BTC',
+            'receivedQuantity' => new Quantity('1'),
+            'receivedAssetIsNft' => false,
+            'transactionFeeCurrency' => null,
+            'transactionFeeQuantity' => Quantity::zero(),
+            'exchangeFeeCurrency' => null,
+            'exchangeFeeQuantity' => Quantity::zero(),
+        ];
+    }
+
+    public function income(): static
+    {
+        return $this->receive()->state([
+            'isIncome' => true,
+        ]);
+    }
+
+    public function receive(): static
+    {
+        return $this->state([
+            'operation' => Operation::Receive,
+            'sentAsset' => null,
+            'sentQuantity' => Quantity::zero(),
+            'receivedAsset' => 'BTC',
+            'receivedQuantity' => new Quantity('1'),
+        ]);
+    }
+}

--- a/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
@@ -4,6 +4,7 @@ use Domain\Aggregates\TaxYear\Actions\RecordIncome;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
 use Domain\Aggregates\TaxYear\TaxYear;
 use Domain\Enums\FiatCurrency;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\IncomeHandlerException;
 use Domain\Services\TransactionDispatcher\Handlers\IncomeHandler;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Transaction;
@@ -25,3 +26,15 @@ it('can handle some income', function () {
         ->once()
         ->withArgs(fn (RecordIncome $action) => $action->amount->isEqualTo($amount));
 });
+
+it('cannot handle some income because the operation is not receive', function () {
+    $taxYearRepository = Mockery::mock(TaxYearRepository::class);
+
+    (new IncomeHandler($taxYearRepository))->handle(Transaction::factory()->send()->make());
+})->throws(IncomeHandlerException::class);
+
+it('cannot handle some income because the transaction is not income', function () {
+    $taxYearRepository = Mockery::mock(TaxYearRepository::class);
+
+    (new IncomeHandler($taxYearRepository))->handle(Transaction::factory()->receive()->make());
+})->throws(IncomeHandlerException::class);

--- a/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Domain\Aggregates\TaxYear\Actions\RecordIncome;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
+use Domain\Aggregates\TaxYear\TaxYear;
+use Domain\Enums\FiatCurrency;
+use Domain\Services\TransactionDispatcher\Handlers\IncomeHandler;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Transaction;
+
+it('can handle some income', function () {
+    $taxYear = Mockery::spy(TaxYear::class);
+
+    $taxYearRepository = Mockery::mock(TaxYearRepository::class)
+        ->shouldReceive('get')
+        ->once()
+        ->andReturn($taxYear)
+        ->getMock();
+
+    $amount = new FiatAmount('50', FiatCurrency::GBP);
+
+    (new IncomeHandler($taxYearRepository))->handle(Transaction::factory()->income()->make(['costBasis' => $amount]));
+
+    $taxYear->shouldHaveReceived('recordIncome')
+        ->once()
+        ->withArgs(fn (RecordIncome $action) => $action->amount->isEqualTo($amount));
+});


### PR DESCRIPTION
## Summary

This PR introduces a handler for income transactions.

## Explanation

Some transactions, such as airdrops, sometimes constitute income. Such transactions will be passed on to the `IncomeHandler` introduced with this PR, which retrieves the relevant `TaxYear` aggregate and has it record the income accordingly.

The PR also introduces the `Transaction` value object, although it will probably change as other handlers are being added.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
