### PR TITLE
Transfer handler

### DIFF
--- a/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/TransferHandlerException.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/TransferHandlerException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers\Exceptions;
+
+use Domain\ValueObjects\Transaction;
+use RuntimeException;
+
+final class TransferHandlerException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidTransaction(string $error, Transaction $transaction): self
+    {
+        return new self(sprintf('Invalid transaction: %s. Transaction: %s', $error, $transaction->__toString()));
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers;
+
+use Domain\Aggregates\TaxYear\Actions\RecordNonAttributableAllowableCost;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
+use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\TaxYearId;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\TransferHandlerException;
+use Domain\ValueObjects\Transaction;
+
+class TransferHandler
+{
+    public function __construct(private TaxYearRepository $taxYearRepository)
+    {
+    }
+
+    /** @throws TransferHandlerException */
+    public function handle(Transaction $transaction): void
+    {
+        $this->validate($transaction);
+
+        if ($this->transactionHasNoFee($transaction)) {
+            return;
+        }
+
+        $taxYear = TaxYearGenerator::fromYear($transaction->date->getYear());
+        $taxYearId = TaxYearId::fromTaxYear($taxYear);
+        $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
+
+        if ($transaction->transactionFeeCostBasis?->isGreaterThan('0')) {
+            $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
+                taxYear: $taxYear,
+                amount: $transaction->transactionFeeCostBasis,
+            ));
+        }
+
+        if ($transaction->exchangeFeeCostBasis?->isGreaterThan('0')) {
+            $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
+                taxYear: $taxYear,
+                amount: $transaction->exchangeFeeCostBasis,
+            ));
+        }
+    }
+
+    /** @throws TransferHandlerException */
+    private function validate(Transaction $transaction): void
+    {
+        $transaction->isTransfer() || throw TransferHandlerException::invalidTransaction('not transfer', $transaction);
+    }
+
+    private function transactionHasNoFee(Transaction $transaction): bool
+    {
+        return (bool) ($transaction->transactionFeeCostBasis?->isGreaterThan('0')) === false
+            && (bool) ($transaction->exchangeFeeCostBasis?->isGreaterThan('0')) === false;
+    }
+}

--- a/domain/src/ValueObjects/Transaction.php
+++ b/domain/src/ValueObjects/Transaction.php
@@ -29,8 +29,10 @@ final class Transaction implements Stringable
         public readonly bool $receivedAssetIsNft,
         public readonly ?string $transactionFeeCurrency,
         public readonly Quantity $transactionFeeQuantity,
+        public readonly ?FiatAmount $transactionFeeCostBasis,
         public readonly ?string $exchangeFeeCurrency,
         public readonly Quantity $exchangeFeeQuantity,
+        public readonly ?FiatAmount $exchangeFeeCostBasis,
     ) {
         match ($operation) {
             Operation::Receive => $this->validateReceive($sentAsset, $receivedAsset, $receivedQuantity),

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -36,8 +36,10 @@ class TransactionFactory extends PlainObjectFactory
             'receivedAssetIsNft' => false,
             'transactionFeeCurrency' => null,
             'transactionFeeQuantity' => Quantity::zero(),
+            'transactionFeeCostBasis' => null,
             'exchangeFeeCurrency' => null,
             'exchangeFeeQuantity' => Quantity::zero(),
+            'exchangeFeeCostBasis' => null,
         ];
     }
 
@@ -84,11 +86,29 @@ class TransactionFactory extends PlainObjectFactory
     public function transfer(): static
     {
         return $this->state([
-            'operation' => Operation::Send,
+            'operation' => Operation::Transfer,
             'sentAsset' => 'BTC',
             'sentQuantity' => new Quantity('1'),
             'receivedAsset' => null,
             'receivedQuantity' => Quantity::zero(),
+        ]);
+    }
+
+    public function withTransactionFee(?FiatAmount $costBasis = null): static
+    {
+        return $this->state([
+            'transactionFeeCurrency' => 'BTC',
+            'transactionFeeQuantity' => new Quantity('0.0001'),
+            'transactionFeeCostBasis' => $costBasis ?? new FiatAmount('10', FiatCurrency::GBP),
+        ]);
+    }
+
+    public function withExchangeFee(?FiatAmount $costBasis = null): static
+    {
+        return $this->state([
+            'exchangeFeeCurrency' => 'BTC',
+            'exchangeFeeQuantity' => new Quantity('0.0001'),
+            'exchangeFeeCostBasis' => $costBasis ?? new FiatAmount('10', FiatCurrency::GBP),
         ]);
     }
 }

--- a/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Domain\Aggregates\TaxYear\Actions\RecordNonAttributableAllowableCost;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
+use Domain\Aggregates\TaxYear\TaxYear;
+use Domain\Enums\FiatCurrency;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\TransferHandlerException;
+use Domain\Services\TransactionDispatcher\Handlers\TransferHandler;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Transaction;
+
+it('can handle a non-attributable allowable cost', function () {
+    $taxYear = Mockery::spy(TaxYear::class);
+
+    $taxYearRepository = Mockery::mock(TaxYearRepository::class)
+        ->shouldReceive('get')
+        ->once()
+        ->andReturn($taxYear)
+        ->getMock();
+
+    $transaction = Transaction::factory()
+        ->transfer()
+        ->withTransactionFee($transactionFee = new FiatAmount('5', FiatCurrency::GBP))
+        ->withExchangeFee($exchangeFee = new FiatAmount('10', FiatCurrency::GBP))
+        ->make();
+
+    (new TransferHandler($taxYearRepository))->handle($transaction);
+
+    $taxYear->shouldHaveReceived('recordNonAttributableAllowableCost')
+        ->withArgs(fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($transactionFee))
+        ->withArgs(fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($exchangeFee));
+});
+
+it('can handle a zero non-attributable allowable cost', function () {
+    $taxYearRepository = Mockery::spy(TaxYearRepository::class);
+
+    (new TransferHandler($taxYearRepository))->handle(Transaction::factory()->transfer()->make());
+
+    $taxYearRepository->shouldNotHaveReceived('get');
+});
+
+it('cannot handle a non-attributable allowable cost because the operation is not transfer', function () {
+    $taxYearRepository = Mockery::mock(TaxYearRepository::class);
+
+    (new TransferHandler($taxYearRepository))->handle(Transaction::factory()->send()->make());
+})->throws(TransferHandlerException::class);


### PR DESCRIPTION
## Summary

This PR introduces a handler for transfer operations.

## Explanation

Transfer fees cannot be attributed to an asset, because the transferred asset is neither acquired nor disposed of. Transfer fees thus constitute non-attributable allowable costs, which should be recorded to be deducted from any capital gains upon completing one's tax return.

The `TransferHandler` introduced with this PR deals with this, having the relevant `TaxYear` aggregate record the cost basis of the transaction fee and/or of the exchange fee as non-attributable allowable costs, when those are non-zero.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
