### PR TITLE
NFT handler

### DIFF
--- a/domain/src/Aggregates/Nft/Nft.php
+++ b/domain/src/Aggregates/Nft/Nft.php
@@ -17,7 +17,7 @@ use EventSauce\EventSourcing\AggregateRootBehaviour;
 use EventSauce\EventSourcing\AggregateRootId;
 
 /** @property NftId $aggregateRootId */
-final class Nft implements AggregateRoot
+class Nft implements AggregateRoot
 {
     use AggregateRootBehaviour;
 

--- a/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/NftHandlerException.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/NftHandlerException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers\Exceptions;
+
+use Domain\ValueObjects\Transaction;
+use RuntimeException;
+
+final class NftHandlerException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidTransaction(string $error, Transaction $transaction): self
+    {
+        return new self(sprintf('Invalid transaction: %s. Transaction: %s', $error, $transaction->__toString()));
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers;
+
+use Domain\Aggregates\Nft\Actions\AcquireNft;
+use Domain\Aggregates\Nft\Actions\DisposeOfNft;
+use Domain\Aggregates\Nft\Repositories\NftRepository;
+use Domain\Aggregates\Nft\NftId;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\NftHandlerException;
+use Domain\ValueObjects\Transaction;
+
+class NftHandler
+{
+    public function __construct(private NftRepository $nftRepository)
+    {
+    }
+
+    /** @throws NftHandlerException */
+    public function handle(Transaction $transaction): void
+    {
+        $this->validate($transaction);
+
+        if ($transaction->receivedAssetIsNft) {
+            $this->handleReceive($transaction);
+        }
+
+        if ($transaction->sentAssetIsNft) {
+            $this->handleSend($transaction);
+        }
+    }
+
+    /** @throws NftHandlerException */
+    private function validate(Transaction $transaction): void
+    {
+        $transaction->isReceive()
+            || $transaction->isSend()
+            || $transaction->isSwap()
+            || throw NftHandlerException::invalidTransaction('unsupported operation', $transaction);
+
+        $transaction->receivedAssetIsNft
+            || $transaction->sentAssetIsNft
+            || throw NftHandlerException::invalidTransaction('neither asset is a NFT', $transaction);
+    }
+
+    private function handleReceive(Transaction $transaction): void
+    {
+        assert($transaction->receivedAsset !== null);
+
+        $nftId = NftId::fromNftId($transaction->receivedAsset);
+        $nftAggregate = $this->nftRepository->get($nftId);
+
+        $nftAggregate->acquire(new AcquireNft($transaction->date, $transaction->costBasis));
+    }
+
+    private function handleSend(Transaction $transaction): void
+    {
+        assert($transaction->sentAsset !== null);
+
+        $nftId = NftId::fromNftId($transaction->sentAsset);
+        $nftAggregate = $this->nftRepository->get($nftId);
+
+        $nftAggregate->disposeOf(new DisposeOfNft($transaction->date, $transaction->costBasis));
+    }
+}

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -43,13 +43,6 @@ class TransactionFactory extends PlainObjectFactory
         ];
     }
 
-    public function income(): static
-    {
-        return $this->receive()->state([
-            'isIncome' => true,
-        ]);
-    }
-
     public function receive(): static
     {
         return $this->state([
@@ -58,6 +51,21 @@ class TransactionFactory extends PlainObjectFactory
             'sentQuantity' => Quantity::zero(),
             'receivedAsset' => 'BTC',
             'receivedQuantity' => new Quantity('1'),
+        ]);
+    }
+
+    public function income(): static
+    {
+        return $this->receive()->state([
+            'isIncome' => true,
+        ]);
+    }
+
+    public function receiveNft(): static
+    {
+        return $this->receive()->state([
+            'receivedAsset' => md5(time() . 'receive'),
+            'receivedAssetIsNft' => true,
         ]);
     }
 
@@ -72,15 +80,44 @@ class TransactionFactory extends PlainObjectFactory
         ]);
     }
 
+    public function sendNft(): static
+    {
+        return $this->send()->state([
+            'sentAsset' => md5(time() . 'send'),
+            'sentAssetIsNft' => true,
+        ]);
+    }
+
     public function swap(): static
     {
         return $this->state([
-            'operation' => Operation::Send,
+            'operation' => Operation::Swap,
             'sentAsset' => 'BTC',
             'sentQuantity' => new Quantity('1'),
             'receivedAsset' => 'ETH',
             'receivedQuantity' => new Quantity('10'),
         ]);
+    }
+
+    public function swapToNft(): static
+    {
+        return $this->swap()->state([
+            'receivedAsset' => md5(time() . 'receive'),
+            'receivedAssetIsNft' => true,
+        ]);
+    }
+
+    public function swapFromNft(): static
+    {
+        return $this->swap()->state([
+            'sentAsset' => md5(time() . 'send'),
+            'sentAssetIsNft' => true,
+        ]);
+    }
+
+    public function swapNfts(): static
+    {
+        return $this->swapToNft()->swapFromNft();
     }
 
     public function transfer(): static

--- a/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Brick\DateTime\LocalDate;
+use Domain\Aggregates\Nft\Actions\AcquireNft;
+use Domain\Aggregates\Nft\Actions\DisposeOfNft;
+use Domain\Aggregates\Nft\Repositories\NftRepository;
+use Domain\Aggregates\Nft\Nft;
+use Domain\Enums\FiatCurrency;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\NftHandlerException;
+use Domain\Services\TransactionDispatcher\Handlers\NftHandler;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Transaction;
+
+beforeEach(function () {
+    $this->nftRepository = Mockery::mock(NftRepository::class);
+});
+
+it('can handle a receive operation', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    $transaction = Transaction::factory()->receiveNft()->make([
+        'date' => LocalDate::parse('2015-10-21'),
+        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+    ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a send operation', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    $transaction = Transaction::factory()->sendNft()->make([
+        'date' => LocalDate::parse('2015-10-21'),
+        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+    ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where the received asset is a NFT', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    $transaction = Transaction::factory()->swapToNft()->make([
+        'date' => LocalDate::parse('2015-10-21'),
+        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+    ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where the sent asset is a NFT', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    $transaction = Transaction::factory()->swapFromNft()->make([
+        'date' => LocalDate::parse('2015-10-21'),
+        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+    ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where both assets are NFTs', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->twice()->andReturn($nft);
+
+    $transaction = Transaction::factory()->swapNfts()->make([
+        'date' => LocalDate::parse('2015-10-21'),
+        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+    ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->costBasis));
+
+    $nft->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('cannot handle a transaction because the operation is not supported', function () {
+    (new NftHandler($this->nftRepository))->handle(Transaction::factory()->transfer()->make());
+})->throws(NftHandlerException::class);
+
+it('cannot handle a transaction because none of the assets is a NFT', function () {
+    (new NftHandler($this->nftRepository))->handle(Transaction::factory()->swap()->make());
+})->throws(NftHandlerException::class);


### PR DESCRIPTION
## Summary

This PR introduces a handler for transactions involving NFTs.

## Explanation

The new `NftHandler` caters for the following transactions:

* "Receive" transactions where the received asset is an NFT;
* "Send" transactions where the sent asset is an NFT;
* "Swap" transactions where either the received asset or the sent asset is an NFT; and
* "Swap" transactions where both assets are NFTs.

Depending on the scenario, it retrieves the relevant `Nft` aggregate root and acquire and/or dispose of the NFT.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
