### PR TITLE
Share pooling handler

### DIFF
--- a/domain/src/Aggregates/Nft/Reactors/NftReactor.php
+++ b/domain/src/Aggregates/Nft/Reactors/NftReactor.php
@@ -8,7 +8,7 @@ use Domain\Aggregates\Nft\Events\NftDisposedOf;
 use Domain\Aggregates\TaxYear\Actions\RecordCapitalGain;
 use Domain\Aggregates\TaxYear\Actions\RecordCapitalLoss;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
-use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\Services\TaxYearNormaliser\TaxYearNormaliser;
 use Domain\Aggregates\TaxYear\TaxYearId;
 use EventSauce\EventSourcing\EventConsumption\EventConsumer;
 use EventSauce\EventSourcing\Message;
@@ -21,7 +21,7 @@ final class NftReactor extends EventConsumer
 
     public function handleNftDisposedOf(NftDisposedOf $event, Message $message): void
     {
-        $taxYear = TaxYearGenerator::fromYear($event->date->getYear());
+        $taxYear = TaxYearNormaliser::fromYear($event->date->getYear());
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
+++ b/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
@@ -11,7 +11,7 @@ use Domain\Aggregates\TaxYear\Actions\RecordCapitalLoss;
 use Domain\Aggregates\TaxYear\Actions\RevertCapitalGain;
 use Domain\Aggregates\TaxYear\Actions\RevertCapitalLoss;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
-use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\Services\TaxYearNormaliser\TaxYearNormaliser;
 use Domain\Aggregates\TaxYear\TaxYearId;
 use EventSauce\EventSourcing\EventConsumption\EventConsumer;
 use EventSauce\EventSourcing\Message;
@@ -25,7 +25,7 @@ final class SharePoolingReactor extends EventConsumer
     public function handleSharePoolingTokenDisposedOf(SharePoolingTokenDisposedOf $event, Message $message): void
     {
         $disposal = $event->sharePoolingTokenDisposal;
-        $taxYear = TaxYearGenerator::fromYear($disposal->date->getYear());
+        $taxYear = TaxYearNormaliser::fromYear($disposal->date->getYear());
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 
@@ -47,7 +47,7 @@ final class SharePoolingReactor extends EventConsumer
     public function handleSharePoolingTokenDisposalReverted(SharePoolingTokenDisposalReverted $event, Message $message): void
     {
         $disposal = $event->sharePoolingTokenDisposal;
-        $taxYear = TaxYearGenerator::fromYear($disposal->date->getYear());
+        $taxYear = TaxYearNormaliser::fromYear($disposal->date->getYear());
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Aggregates/SharePooling/Services/AssetSymbolNormaliser/AssetSymbolNormaliser.php
+++ b/domain/src/Aggregates/SharePooling/Services/AssetSymbolNormaliser/AssetSymbolNormaliser.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Aggregates\SharePooling\Services\AssetSymbolNormaliser;
+
+final class AssetSymbolNormaliser
+{
+    public static function normalise(?string $symbol): ?string
+    {
+        return is_null($symbol) ? null : trim(strtoupper($symbol));
+    }
+}

--- a/domain/src/Aggregates/SharePooling/SharePooling.php
+++ b/domain/src/Aggregates/SharePooling/SharePooling.php
@@ -25,7 +25,7 @@ use EventSauce\EventSourcing\AggregateRootBehaviour;
 use EventSauce\EventSourcing\AggregateRootId;
 
 /** @property SharePoolingId $aggregateRootId */
-final class SharePooling implements AggregateRoot
+class SharePooling implements AggregateRoot
 {
     use AggregateRootBehaviour;
 

--- a/domain/src/Aggregates/SharePooling/SharePoolingId.php
+++ b/domain/src/Aggregates/SharePooling/SharePoolingId.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Domain\Aggregates\SharePooling;
 
 use Domain\AggregateRootId;
+use Domain\Aggregates\SharePooling\Services\AssetSymbolNormaliser\AssetSymbolNormaliser;
 use Ramsey\Uuid\Uuid;
 
 final class SharePoolingId extends AggregateRootId
 {
     private const NAMESPACE = '94ff3977-46f5-4efe-8a89-e474d375232f';
 
-    public static function fromTokenSymbol(string $tokenSymbol): static
+    public static function fromSymbol(string $symbol): static
     {
-        return self::fromString(Uuid::uuid5(self::NAMESPACE, trim(strtoupper($tokenSymbol)))->toString());
+        // @phpstan-ignore-next-line
+        return self::fromString(Uuid::uuid5(self::NAMESPACE, AssetSymbolNormaliser::normalise($symbol))->toString());
     }
 }

--- a/domain/src/Aggregates/TaxYear/Services/TaxYearNormaliser/TaxYearNormaliser.php
+++ b/domain/src/Aggregates/TaxYear/Services/TaxYearNormaliser/TaxYearNormaliser.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Domain\Aggregates\TaxYear\Services\TaxYearGenerator;
+namespace Domain\Aggregates\TaxYear\Services\TaxYearNormaliser;
 
-final class TaxYearGenerator
+final class TaxYearNormaliser
 {
     public static function fromYear(int $year): string
     {

--- a/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/SharePoolingHandlerException.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Exceptions/SharePoolingHandlerException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers\Exceptions;
+
+use Domain\ValueObjects\Transaction;
+use RuntimeException;
+
+final class SharePoolingHandlerException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidTransaction(string $error, Transaction $transaction): self
+    {
+        return new self(sprintf('Invalid transaction: %s. Transaction: %s', $error, $transaction->__toString()));
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -6,7 +6,7 @@ namespace Domain\Services\TransactionDispatcher\Handlers;
 
 use Domain\Aggregates\TaxYear\Actions\RecordIncome;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
-use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\Services\TaxYearNormaliser\TaxYearNormaliser;
 use Domain\Aggregates\TaxYear\TaxYearId;
 use Domain\Services\TransactionDispatcher\Handlers\Exceptions\IncomeHandlerException;
 use Domain\ValueObjects\Transaction;
@@ -22,7 +22,7 @@ class IncomeHandler
     {
         $this->validate($transaction);
 
-        $taxYear = TaxYearGenerator::fromYear($transaction->date->getYear());
+        $taxYear = TaxYearNormaliser::fromYear($transaction->date->getYear());
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
@@ -22,12 +22,12 @@ class NftHandler
     {
         $this->validate($transaction);
 
-        if ($transaction->receivedAssetIsNft) {
-            $this->handleReceive($transaction);
+        if ($transaction->sentAssetIsNft) {
+            $this->handleDisposal($transaction);
         }
 
-        if ($transaction->sentAssetIsNft) {
-            $this->handleSend($transaction);
+        if ($transaction->receivedAssetIsNft) {
+            $this->handleAcquisition($transaction);
         }
     }
 
@@ -44,23 +44,23 @@ class NftHandler
             || throw NftHandlerException::invalidTransaction('neither asset is a NFT', $transaction);
     }
 
-    private function handleReceive(Transaction $transaction): void
-    {
-        assert($transaction->receivedAsset !== null);
-
-        $nftId = NftId::fromNftId($transaction->receivedAsset);
-        $nftAggregate = $this->nftRepository->get($nftId);
-
-        $nftAggregate->acquire(new AcquireNft($transaction->date, $transaction->costBasis));
-    }
-
-    private function handleSend(Transaction $transaction): void
+    private function handleDisposal(Transaction $transaction): void
     {
         assert($transaction->sentAsset !== null);
 
         $nftId = NftId::fromNftId($transaction->sentAsset);
-        $nftAggregate = $this->nftRepository->get($nftId);
+        $nft = $this->nftRepository->get($nftId);
 
-        $nftAggregate->disposeOf(new DisposeOfNft($transaction->date, $transaction->costBasis));
+        $nft->disposeOf(new DisposeOfNft($transaction->date, $transaction->costBasis));
+    }
+
+    private function handleAcquisition(Transaction $transaction): void
+    {
+        assert($transaction->receivedAsset !== null);
+
+        $nftId = NftId::fromNftId($transaction->receivedAsset);
+        $nft = $this->nftRepository->get($nftId);
+
+        $nft->acquire(new AcquireNft($transaction->date, $transaction->costBasis));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers;
+
+use Domain\Aggregates\SharePooling\Actions\AcquireSharePoolingToken;
+use Domain\Aggregates\SharePooling\Actions\DisposeOfSharePoolingToken;
+use Domain\Aggregates\SharePooling\Repositories\SharePoolingRepository;
+use Domain\Aggregates\SharePooling\SharePoolingId;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\SharePoolingHandlerException;
+use Domain\ValueObjects\Transaction;
+
+class SharePoolingHandler
+{
+    public function __construct(private SharePoolingRepository $sharePoolingRepository)
+    {
+    }
+
+    /** @throws SharePoolingHandlerException */
+    public function handle(Transaction $transaction): void
+    {
+        $this->validate($transaction);
+
+        if (! is_null($transaction->sentAsset) && ! $transaction->sentAssetIsNft) {
+            $this->handleDisposal($transaction);
+        }
+
+        if (! is_null($transaction->receivedAsset) && ! $transaction->receivedAssetIsNft) {
+            $this->handleAcquisition($transaction);
+        }
+    }
+
+    /** @throws SharePoolingHandlerException */
+    private function validate(Transaction $transaction): void
+    {
+        $transaction->isReceive()
+            || $transaction->isSend()
+            || $transaction->isSwap()
+            || throw SharePoolingHandlerException::invalidTransaction('unsupported operation', $transaction);
+
+        $transaction->receivedAssetIsNft
+            && $transaction->sentAssetIsNft
+            && throw SharePoolingHandlerException::invalidTransaction('both assets are NFTs', $transaction);
+    }
+
+    private function handleDisposal(Transaction $transaction): void
+    {
+        assert($transaction->sentAsset !== null);
+
+        $sharePoolingId = SharePoolingId::fromSymbol($transaction->sentAsset);
+        $sharePooling = $this->sharePoolingRepository->get($sharePoolingId);
+
+        $sharePooling->disposeOf(new DisposeOfSharePoolingToken(
+            date: $transaction->date,
+            quantity: $transaction->sentQuantity,
+            proceeds: $transaction->costBasis,
+        ));
+    }
+
+    private function handleAcquisition(Transaction $transaction): void
+    {
+        assert($transaction->receivedAsset !== null);
+
+        $sharePoolingId = SharePoolingId::fromSymbol($transaction->receivedAsset);
+        $sharePooling = $this->sharePoolingRepository->get($sharePoolingId);
+
+        $sharePooling->acquire(new AcquireSharePoolingToken(
+            date: $transaction->date,
+            quantity: $transaction->receivedQuantity,
+            costBasis: $transaction->costBasis,
+        ));
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -6,7 +6,7 @@ namespace Domain\Services\TransactionDispatcher\Handlers;
 
 use Domain\Aggregates\TaxYear\Actions\RecordNonAttributableAllowableCost;
 use Domain\Aggregates\TaxYear\Repositories\TaxYearRepository;
-use Domain\Aggregates\TaxYear\Services\TaxYearGenerator\TaxYearGenerator;
+use Domain\Aggregates\TaxYear\Services\TaxYearNormaliser\TaxYearNormaliser;
 use Domain\Aggregates\TaxYear\TaxYearId;
 use Domain\Services\TransactionDispatcher\Handlers\Exceptions\TransferHandlerException;
 use Domain\ValueObjects\Transaction;
@@ -26,7 +26,7 @@ class TransferHandler
             return;
         }
 
-        $taxYear = TaxYearGenerator::fromYear($transaction->date->getYear());
+        $taxYear = TaxYearNormaliser::fromYear($transaction->date->getYear());
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/tests/Services/TransactionDispatcher/Handlers/SharePoolingHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/SharePoolingHandlerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Domain\Aggregates\SharePooling\Actions\AcquireSharePoolingToken;
+use Domain\Aggregates\SharePooling\Actions\DisposeOfSharePoolingToken;
+use Domain\Aggregates\SharePooling\Repositories\SharePoolingRepository;
+use Domain\Aggregates\SharePooling\SharePooling;
+use Domain\Enums\FiatCurrency;
+use Domain\Services\TransactionDispatcher\Handlers\Exceptions\SharePoolingHandlerException;
+use Domain\Services\TransactionDispatcher\Handlers\SharePoolingHandler;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Transaction;
+
+beforeEach(function () {
+    $this->sharePoolingRepository = Mockery::mock(SharePoolingRepository::class);
+});
+
+it('can handle a receive operation', function () {
+    $sharePooling = Mockery::spy(SharePooling::class);
+
+    $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
+
+    $transaction = Transaction::factory()->receive()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
+
+    $sharePooling->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a send operation', function () {
+    $sharePooling = Mockery::spy(SharePooling::class);
+
+    $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
+
+    $transaction = Transaction::factory()->send()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
+
+    $sharePooling->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where the received asset is not a NFT', function () {
+    $sharePooling = Mockery::spy(SharePooling::class);
+
+    $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
+
+    $transaction = Transaction::factory()->swapFromNft()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
+
+    $sharePooling->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where the sent asset is not a NFT', function () {
+    $sharePooling = Mockery::spy(SharePooling::class);
+
+    $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
+
+    $transaction = Transaction::factory()->swapToNft()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
+
+    $sharePooling->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+});
+
+it('can handle a swap operation where neither asset is a NFT', function () {
+    $sharePooling = Mockery::spy(SharePooling::class);
+
+    $this->sharePoolingRepository->shouldReceive('get')->twice()->andReturn($sharePooling);
+
+    $transaction = Transaction::factory()->swap()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
+
+    $sharePooling->shouldHaveReceived('disposeOf')
+        ->once()
+        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+
+    $sharePooling->shouldHaveReceived('acquire')
+        ->once()
+        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+});
+
+it('cannot handle a transaction because the operation is not supported', function () {
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle(Transaction::factory()->transfer()->make());
+})->throws(SharePoolingHandlerException::class);
+
+it('cannot handle a transaction because one of the assets is a NFT', function () {
+    (new SharePoolingHandler($this->sharePoolingRepository))->handle(Transaction::factory()->swapNfts()->make());
+})->throws(SharePoolingHandlerException::class);


### PR DESCRIPTION
## Summary

This PR introduces a handler for transactions involving assets subject to share pooling rules.

## Explanation

The new `SharePoolingHandler` caters for the following transactions:

* "Receive" transactions where the received asset is subject to share pooling rules;
* "Send" transactions where the sent asset is subject to share pooling rules;
* "Swap" transactions where either the received asset or the sent asset is subject to share pooling rules; and
* "Swap" transactions where both assets are subject to share pooling rules.

Depending on the scenario, it retrieves the relevant `SharePooling` aggregate root and acquire and/or dispose of the asset.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
