### PR TITLE
Transaction dispatcher

### DIFF
--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -26,7 +26,8 @@ class IncomeHandler
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 
-        $taxYearAggregate->recordIncome(new RecordIncome(taxYear: $taxYear, amount: $transaction->costBasis));
+        // @phpstan-ignore-next-line
+        $taxYearAggregate->recordIncome(new RecordIncome(taxYear: $taxYear, amount: $transaction->marketValue));
     }
 
     /** @throws IncomeHandlerException */

--- a/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/NftHandler.php
@@ -49,7 +49,8 @@ class NftHandler
         $nftId = NftId::fromNftId($transaction->sentAsset);
         $nft = $this->nftRepository->get($nftId);
 
-        $nft->disposeOf(new DisposeOfNft($transaction->date, $transaction->costBasis));
+        // @phpstan-ignore-next-line
+        $nft->disposeOf(new DisposeOfNft($transaction->date, $transaction->marketValue));
     }
 
     private function handleAcquisition(Transaction $transaction): void
@@ -59,6 +60,7 @@ class NftHandler
         $nftId = NftId::fromNftId($transaction->receivedAsset);
         $nft = $this->nftRepository->get($nftId);
 
-        $nft->acquire(new AcquireNft($transaction->date, $transaction->costBasis));
+        // @phpstan-ignore-next-line
+        $nft->acquire(new AcquireNft($transaction->date, $transaction->marketValue));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
@@ -54,7 +54,7 @@ class SharePoolingHandler
         $sharePooling->disposeOf(new DisposeOfSharePoolingToken(
             date: $transaction->date,
             quantity: $transaction->sentQuantity,
-            proceeds: $transaction->costBasis,
+            proceeds: $transaction->marketValue, // @phpstan-ignore-line
         ));
     }
 
@@ -68,7 +68,7 @@ class SharePoolingHandler
         $sharePooling->acquire(new AcquireSharePoolingToken(
             date: $transaction->date,
             quantity: $transaction->receivedQuantity,
-            costBasis: $transaction->costBasis,
+            costBasis: $transaction->marketValue, // @phpstan-ignore-line
         ));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/SharePoolingHandler.php
@@ -9,10 +9,13 @@ use Domain\Aggregates\SharePooling\Actions\DisposeOfSharePoolingToken;
 use Domain\Aggregates\SharePooling\Repositories\SharePoolingRepository;
 use Domain\Aggregates\SharePooling\SharePoolingId;
 use Domain\Services\TransactionDispatcher\Handlers\Exceptions\SharePoolingHandlerException;
+use Domain\Services\TransactionDispatcher\Handlers\Traits\AttributesFees;
 use Domain\ValueObjects\Transaction;
 
 class SharePoolingHandler
 {
+    use AttributesFees;
+
     public function __construct(private SharePoolingRepository $sharePoolingRepository)
     {
     }
@@ -54,7 +57,7 @@ class SharePoolingHandler
         $sharePooling->disposeOf(new DisposeOfSharePoolingToken(
             date: $transaction->date,
             quantity: $transaction->sentQuantity,
-            proceeds: $transaction->marketValue, // @phpstan-ignore-line
+            proceeds: $transaction->marketValue->minus($this->splitFees($transaction)), // @phpstan-ignore-line
         ));
     }
 
@@ -68,7 +71,7 @@ class SharePoolingHandler
         $sharePooling->acquire(new AcquireSharePoolingToken(
             date: $transaction->date,
             quantity: $transaction->receivedQuantity,
-            costBasis: $transaction->marketValue, // @phpstan-ignore-line
+            costBasis: $transaction->marketValue->plus($this->splitFees($transaction)), // @phpstan-ignore-line
         ));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/Traits/AttributesFees.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Traits/AttributesFees.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher\Handlers\Traits;
+
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Transaction;
+
+trait AttributesFees
+{
+    private function splitFees(Transaction $transaction): FiatAmount
+    {
+        $amount = $transaction->hasNetworkFee()
+            ? $transaction->networkFeeMarketValue
+            : $transaction->marketValue->nilAmount(); // @phpstan-ignore-line
+
+        if ($transaction->hasPlatformFee()) {
+            $amount = $amount->plus($transaction->platformFeeMarketValue); // @phpstan-ignore-line
+        }
+
+        return $transaction->isSwap() ? $amount->dividedBy('2') : $amount; // @phpstan-ignore-line
+    }
+}

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -30,17 +30,17 @@ class TransferHandler
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 
-        if ($transaction->transactionFeeCostBasis?->isGreaterThan('0')) {
+        if ($transaction->networkFeeMarketValue?->isGreaterThan('0')) {
             $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
                 taxYear: $taxYear,
-                amount: $transaction->transactionFeeCostBasis,
+                amount: $transaction->networkFeeMarketValue,
             ));
         }
 
-        if ($transaction->exchangeFeeCostBasis?->isGreaterThan('0')) {
+        if ($transaction->platformFeeMarketValue?->isGreaterThan('0')) {
             $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
                 taxYear: $taxYear,
-                amount: $transaction->exchangeFeeCostBasis,
+                amount: $transaction->platformFeeMarketValue,
             ));
         }
     }
@@ -53,7 +53,7 @@ class TransferHandler
 
     private function transactionHasNoFee(Transaction $transaction): bool
     {
-        return (bool) ($transaction->transactionFeeCostBasis?->isGreaterThan('0')) === false
-            && (bool) ($transaction->exchangeFeeCostBasis?->isGreaterThan('0')) === false;
+        return (bool) ($transaction->networkFeeMarketValue?->isGreaterThan('0')) === false
+            && (bool) ($transaction->platformFeeMarketValue?->isGreaterThan('0')) === false;
     }
 }

--- a/domain/src/Services/TransactionDispatcher/TransactionDispatcher.php
+++ b/domain/src/Services/TransactionDispatcher/TransactionDispatcher.php
@@ -77,7 +77,7 @@ final class TransactionDispatcher
 
     private function handleNetworkFee(Transaction $transaction): self
     {
-        if (is_null($transaction->networkFeeMarketValue) || $transaction->networkFeeIsFiat()) {
+        if (! $transaction->hasNetworkFee() || $transaction->networkFeeIsFiat()) {
             return $this;
         }
 
@@ -94,7 +94,7 @@ final class TransactionDispatcher
 
     private function handlePlatformFee(Transaction $transaction): self
     {
-        if (is_null($transaction->platformFeeMarketValue) || $transaction->platformFeeIsFiat()) {
+        if (! $transaction->hasPlatformFee() || $transaction->platformFeeIsFiat()) {
             return $this;
         }
 

--- a/domain/src/Services/TransactionDispatcher/TransactionDispatcher.php
+++ b/domain/src/Services/TransactionDispatcher/TransactionDispatcher.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Services\TransactionDispatcher;
+
+use Domain\Enums\Operation;
+use Domain\Services\TransactionDispatcher\Handlers\IncomeHandler;
+use Domain\Services\TransactionDispatcher\Handlers\NftHandler;
+use Domain\Services\TransactionDispatcher\Handlers\SharePoolingHandler;
+use Domain\Services\TransactionDispatcher\Handlers\TransferHandler;
+use Domain\ValueObjects\Transaction;
+
+final class TransactionDispatcher
+{
+    public function __construct(
+        private readonly IncomeHandler $incomeHandler,
+        private readonly TransferHandler $transferHandler,
+        private readonly NftHandler $nftHandler,
+        private readonly SharePoolingHandler $sharePoolingHandler,
+    ) {
+    }
+
+    public function dispatch(Transaction $transaction): void
+    {
+        $this->handleIncome($transaction)
+            ->handleTransfer($transaction)
+            ->handleNft($transaction)
+            ->handleSharePooling($transaction)
+            ->handleTransactionFee($transaction)
+            ->handleExchangeFee($transaction);
+    }
+
+    private function handleIncome(Transaction $transaction): self
+    {
+        if (! $transaction->isIncome) {
+            return $this;
+        }
+
+        $this->incomeHandler->handle($transaction);
+
+        return $this;
+    }
+
+    private function handleTransfer(Transaction $transaction): self
+    {
+        if (! $transaction->isTransfer()) {
+            return $this;
+        }
+
+        $this->transferHandler->handle($transaction);
+
+        return $this;
+    }
+
+    private function handleNft(Transaction $transaction): self
+    {
+        if (! $transaction->involvesNfts()) {
+            return $this;
+        }
+
+        $this->nftHandler->handle($transaction);
+
+        return $this;
+    }
+
+    private function handleSharePooling(Transaction $transaction): self
+    {
+        if (! $transaction->involvesSharePooling()) {
+            return $this;
+        }
+
+        $this->sharePoolingHandler->handle($transaction);
+
+        return $this;
+    }
+
+    private function handleTransactionFee(Transaction $transaction): self
+    {
+        if (is_null($transaction->transactionFeeCostBasis)) {
+            return $this;
+        }
+
+        $this->sharePoolingHandler->handle(new Transaction(
+            date: $transaction->date,
+            operation: Operation::Send,
+            costBasis: $transaction->transactionFeeCostBasis,
+            sentAsset: $transaction->transactionFeeCurrency,
+            sentQuantity: $transaction->transactionFeeQuantity,
+        ));
+
+        return $this;
+    }
+
+    private function handleExchangeFee(Transaction $transaction): self
+    {
+        if (is_null($transaction->exchangeFeeCostBasis)) {
+            return $this;
+        }
+
+        $this->sharePoolingHandler->handle(new Transaction(
+            date: $transaction->date,
+            operation: Operation::Send,
+            costBasis: $transaction->exchangeFeeCostBasis,
+            sentAsset: $transaction->exchangeFeeCurrency,
+            sentQuantity: $transaction->exchangeFeeQuantity,
+        ));
+
+        return $this;
+    }
+}

--- a/domain/src/ValueObjects/Transaction.php
+++ b/domain/src/ValueObjects/Transaction.php
@@ -94,9 +94,19 @@ final class Transaction implements Stringable
         return ! $this->sentAssetIsNft || ! $this->receivedAssetIsNft;
     }
 
+    public function hasNetworkFee(): bool
+    {
+        return $this->networkFeeMarketValue?->isGreaterThan('0') ?? false;
+    }
+
     public function networkFeeIsFiat(): bool
     {
         return $this->networkFeeCurrency ? FiatCurrency::tryFrom($this->networkFeeCurrency) !== null : false;
+    }
+
+    public function hasPlatformFee(): bool
+    {
+        return $this->platformFeeMarketValue?->isGreaterThan('0') ?? false;
     }
 
     public function platformFeeIsFiat(): bool

--- a/domain/tests/Aggregates/Nft/Reactors/NftReactorTest.php
+++ b/domain/tests/Aggregates/Nft/Reactors/NftReactorTest.php
@@ -27,9 +27,12 @@ it('can handle a capital gain', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($nftDisposedOf))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalGain')
-            ->once()
-            ->withArgs(fn (RecordCapitalGain $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'recordCapitalGain',
+                fn (RecordCapitalGain $action) => $action->amount->isEqualTo('1'),
+            )->once();
+        });
 });
 
 it('can handle a capital loss', function () {
@@ -46,7 +49,10 @@ it('can handle a capital loss', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($nftDisposedOf))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalLoss')
-            ->once()
-            ->withArgs(fn (RecordCapitalLoss $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'recordCapitalLoss',
+                fn (RecordCapitalLoss $action) => $action->amount->isEqualTo('1'),
+            )->once();
+        });
 });

--- a/domain/tests/Aggregates/SharePooling/Reactors/SharePoolingReactorTest.php
+++ b/domain/tests/Aggregates/SharePooling/Reactors/SharePoolingReactorTest.php
@@ -38,9 +38,12 @@ it('can handle a capital gain', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($sharePoolingTokenDisposedOf))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalGain')
-            ->once()
-            ->withArgs(fn (RecordCapitalGain $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'recordCapitalGain',
+                fn (RecordCapitalGain $action) => $action->amount->isEqualTo('1')
+            )->once();
+        });
 });
 
 it('can handle a capital loss', function () {
@@ -62,9 +65,12 @@ it('can handle a capital loss', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($sharePoolingTokenDisposedOf))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('recordCapitalLoss')
-            ->once()
-            ->withArgs(fn (RecordCapitalLoss $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'recordCapitalLoss',
+                fn (RecordCapitalLoss $action) => $action->amount->isEqualTo('1')
+            )->once();
+        });
 });
 
 it('can handle a capital gain reversion', function () {
@@ -86,9 +92,12 @@ it('can handle a capital gain reversion', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($sharePoolingTokenDisposalReverted))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('revertCapitalGain')
-            ->once()
-            ->withArgs(fn (RevertCapitalGain $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'revertCapitalGain',
+                fn (RevertCapitalGain $action) => $action->amount->isEqualTo('1')
+            )->once();
+        });
 });
 
 it('can handle a capital loss reversion', function () {
@@ -110,7 +119,10 @@ it('can handle a capital loss reversion', function () {
     /** @var MessageConsumerTestCase $this */
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($sharePoolingTokenDisposalReverted))
-        ->then(fn () => $taxYearSpy->shouldHaveReceived('revertCapitalLoss')
-            ->once()
-            ->withArgs(fn (RevertCapitalLoss $action) => $action->amount->isEqualTo('1')));
+        ->then(function () use ($taxYearSpy) {
+            return $taxYearSpy->shouldHaveReceived(
+                'revertCapitalLoss',
+                fn (RevertCapitalLoss $action) => $action->amount->isEqualTo('1')
+            )->once();
+        });
 });

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -25,12 +25,12 @@ it('can handle a capital gain', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalGainRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalGain')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalGainRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $capitalGainRecorded->amount;
-            }));
+            })
+            ->once());
 });
 
 it('can handle a capital gain reversion', function () {
@@ -43,12 +43,12 @@ it('can handle a capital gain reversion', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalGainReverted))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalGain')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalGainReverted) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $capitalGainReverted->amount;
-            }));
+            })
+            ->once());
 });
 
 it('can handle a capital loss', function () {
@@ -61,12 +61,12 @@ it('can handle a capital loss', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalLossRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordCapitalLoss')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalLossRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $capitalLossRecorded->amount;
-            }));
+            })
+            ->once());
 });
 
 it('can handle a capital loss reversion', function () {
@@ -79,12 +79,12 @@ it('can handle a capital loss reversion', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($capitalLossReverted))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('revertCapitalLoss')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($capitalLossReverted) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $capitalLossReverted->amount;
-            }));
+            })
+            ->once());
 });
 
 it('can handle some income', function () {
@@ -97,12 +97,12 @@ it('can handle some income', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($incomeRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordIncome')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($incomeRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $incomeRecorded->amount;
-            }));
+            })
+            ->once());
 });
 
 it('can handle a non-attributable allowable cost', function () {
@@ -115,10 +115,10 @@ it('can handle a non-attributable allowable cost', function () {
     $this->givenNextMessagesHaveAggregateRootIdOf($this->aggregateRootId)
         ->when(new Message($nonAttributableAllowableCostRecorded))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('recordNonAttributableAllowableCost')
-            ->once()
             ->withArgs(function (AggregateRootId $taxYearId, string $taxYear, FiatAmount $amount) use ($nonAttributableAllowableCostRecorded) {
                 return $taxYearId->toString() === $this->aggregateRootId->toString()
                     && $taxYear === $this->taxYear
                     && $amount === $nonAttributableAllowableCostRecorded->amount;
-            }));
+            })
+            ->once());
 });

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -26,7 +26,7 @@ class TransactionFactory extends PlainObjectFactory
         return [
             'date' => LocalDate::parse('2015-10-21'),
             'operation' => Operation::Receive,
-            'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
+            'marketValue' => new FiatAmount('100', FiatCurrency::GBP),
             'isIncome' => false,
             'sentAsset' => null,
             'sentQuantity' => Quantity::zero(),
@@ -34,12 +34,12 @@ class TransactionFactory extends PlainObjectFactory
             'receivedAsset' => 'BTC',
             'receivedQuantity' => new Quantity('1'),
             'receivedAssetIsNft' => false,
-            'transactionFeeCurrency' => null,
-            'transactionFeeQuantity' => Quantity::zero(),
-            'transactionFeeCostBasis' => null,
-            'exchangeFeeCurrency' => null,
-            'exchangeFeeQuantity' => Quantity::zero(),
-            'exchangeFeeCostBasis' => null,
+            'networkFeeCurrency' => null,
+            'networkFeeQuantity' => Quantity::zero(),
+            'networkFeeMarketValue' => null,
+            'platformFeeCurrency' => null,
+            'platformFeeQuantity' => Quantity::zero(),
+            'platformFeeMarketValue' => null,
         ];
     }
 
@@ -66,6 +66,7 @@ class TransactionFactory extends PlainObjectFactory
         return $this->receive()->state([
             'receivedAsset' => md5(time() . 'receive'),
             'receivedAssetIsNft' => true,
+            'receivedQuantity' => new Quantity('1'),
         ]);
     }
 
@@ -85,6 +86,7 @@ class TransactionFactory extends PlainObjectFactory
         return $this->send()->state([
             'sentAsset' => md5(time() . 'send'),
             'sentAssetIsNft' => true,
+            'sentQuantity' => new Quantity('1'),
         ]);
     }
 
@@ -104,6 +106,7 @@ class TransactionFactory extends PlainObjectFactory
         return $this->swap()->state([
             'receivedAsset' => md5(time() . 'receive'),
             'receivedAssetIsNft' => true,
+            'receivedQuantity' => new Quantity('1'),
         ]);
     }
 
@@ -112,6 +115,7 @@ class TransactionFactory extends PlainObjectFactory
         return $this->swap()->state([
             'sentAsset' => md5(time() . 'send'),
             'sentAssetIsNft' => true,
+            'sentQuantity' => new Quantity('1'),
         ]);
     }
 
@@ -131,21 +135,48 @@ class TransactionFactory extends PlainObjectFactory
         ]);
     }
 
-    public function withTransactionFee(?FiatAmount $costBasis = null): static
+    public function transferNft(): static
     {
-        return $this->state([
-            'transactionFeeCurrency' => 'BTC',
-            'transactionFeeQuantity' => new Quantity('0.0001'),
-            'transactionFeeCostBasis' => $costBasis ?? new FiatAmount('10', FiatCurrency::GBP),
+        return $this->transfer()->state([
+            'sentAsset' => md5(time() . 'send'),
+            'sentAssetIsNft' => true,
+            'sentQuantity' => new Quantity('1'),
         ]);
     }
 
-    public function withExchangeFee(?FiatAmount $costBasis = null): static
+    public function withNetworkFee(?FiatAmount $marketValue = null): static
     {
         return $this->state([
-            'exchangeFeeCurrency' => 'BTC',
-            'exchangeFeeQuantity' => new Quantity('0.0001'),
-            'exchangeFeeCostBasis' => $costBasis ?? new FiatAmount('10', FiatCurrency::GBP),
+            'networkFeeCurrency' => 'BTC',
+            'networkFeeQuantity' => new Quantity('0.0001'),
+            'networkFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
+        ]);
+    }
+
+    public function withNetworkFeeInFiat(?FiatAmount $marketValue = null): static
+    {
+        return $this->state([
+            'networkFeeCurrency' => $marketValue?->currency->value ?? FiatCurrency::GBP->value,
+            'networkFeeQuantity' => new Quantity($marketValue?->amount ?? '10'),
+            'networkFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
+        ]);
+    }
+
+    public function withPlatformFee(?FiatAmount $marketValue = null): static
+    {
+        return $this->state([
+            'platformFeeCurrency' => 'BTC',
+            'platformFeeQuantity' => new Quantity('0.0001'),
+            'platformFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
+        ]);
+    }
+
+    public function withPlatformFeeInFiat(?FiatAmount $marketValue = null): static
+    {
+        return $this->state([
+            'platformFeeCurrency' => $marketValue?->currency->value ?? FiatCurrency::GBP->value,
+            'platformFeeQuantity' => new Quantity($marketValue?->amount ?? '10'),
+            'platformFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
         ]);
     }
 }

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -26,8 +26,8 @@ class TransactionFactory extends PlainObjectFactory
         return [
             'date' => LocalDate::parse('2015-10-21'),
             'operation' => Operation::Receive,
-            'isIncome' => false,
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
+            'isIncome' => false,
             'sentAsset' => null,
             'sentQuantity' => Quantity::zero(),
             'sentAssetIsNft' => false,

--- a/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
@@ -18,13 +18,14 @@ it('can handle an income transaction', function () {
 
     $this->taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);
 
-    $transaction = Transaction::factory()->income()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->income()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new IncomeHandler($this->taxYearRepository))->handle($transaction);
 
-    $taxYear->shouldHaveReceived('recordIncome')
-        ->once()
-        ->withArgs(fn (RecordIncome $action) => $action->amount->isEqualTo($transaction->costBasis));
+    $taxYear->shouldHaveReceived(
+        'recordIncome',
+        fn (RecordIncome $action) => $action->amount->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('cannot handle a transaction because the operation is not receive', function () {

--- a/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
@@ -20,6 +20,7 @@ it('can handle a receive operation', function () {
 
     $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
 
+    /** @var Transaction */
     $transaction = Transaction::factory()->receiveNft()->make([
         'date' => LocalDate::parse('2015-10-21'),
         'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
@@ -29,7 +30,32 @@ it('can handle a receive operation', function () {
 
     $nft->shouldHaveReceived(
         'acquire',
-        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
+});
+
+it('can handle a receive operation with fees', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    /** @var Transaction */
+    $transaction = Transaction::factory()
+        ->receiveNft()
+        ->withNetworkFee(new FiatAmount('4', FiatCurrency::GBP))
+        ->withPlatformFee(new FiatAmount('6', FiatCurrency::GBP))
+        ->make([
+            'date' => LocalDate::parse('2015-10-21'),
+            'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
+        ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived(
+        'acquire',
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo(new FiatAmount('60', FiatCurrency::GBP)),
     )->once();
 });
 
@@ -47,7 +73,31 @@ it('can handle a send operation', function () {
 
     $nft->shouldHaveReceived(
         'disposeOf',
-        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
+});
+
+it('can handle a send operation with fees', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->once()->andReturn($nft);
+
+    $transaction = Transaction::factory()
+        ->sendNft()
+        ->withNetworkFee(new FiatAmount('4', FiatCurrency::GBP))
+        ->withPlatformFee(new FiatAmount('6', FiatCurrency::GBP))
+        ->make([
+            'date' => LocalDate::parse('2015-10-21'),
+            'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
+        ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo(new FiatAmount('40', FiatCurrency::GBP)),
     )->once();
 });
 
@@ -65,7 +115,8 @@ it('can handle a swap operation where the received asset is a NFT', function () 
 
     $nft->shouldHaveReceived(
         'acquire',
-        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->marketValue),
     )->once();
 });
 
@@ -83,7 +134,8 @@ it('can handle a swap operation where the sent asset is a NFT', function () {
 
     $nft->shouldHaveReceived(
         'disposeOf',
-        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->marketValue),
     )->once();
 });
 
@@ -101,12 +153,43 @@ it('can handle a swap operation where both assets are NFTs', function () {
 
     $nft->shouldHaveReceived(
         'disposeOf',
-        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo($transaction->marketValue),
     )->once();
 
     $nft->shouldHaveReceived(
         'acquire',
-        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
+});
+
+it('can handle a swap operation with fees', function () {
+    $nft = Mockery::spy(Nft::class);
+
+    $this->nftRepository->shouldReceive('get')->twice()->andReturn($nft);
+
+    $transaction = Transaction::factory()
+        ->swapNfts()
+        ->withNetworkFee(new FiatAmount('4', FiatCurrency::GBP))
+        ->withPlatformFee(new FiatAmount('6', FiatCurrency::GBP))
+        ->make([
+            'date' => LocalDate::parse('2015-10-21'),
+            'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
+        ]);
+
+    (new NftHandler($this->nftRepository))->handle($transaction);
+
+    $nft->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->proceeds->isEqualTo(new FiatAmount('45', FiatCurrency::GBP)),
+    )->once();
+
+    $nft->shouldHaveReceived(
+        'acquire',
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
+            && $action->costBasis->isEqualTo(new FiatAmount('55', FiatCurrency::GBP)),
     )->once();
 });
 

--- a/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/NftHandlerTest.php
@@ -22,15 +22,15 @@ it('can handle a receive operation', function () {
 
     $transaction = Transaction::factory()->receiveNft()->make([
         'date' => LocalDate::parse('2015-10-21'),
-        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+        'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
     ]);
 
     (new NftHandler($this->nftRepository))->handle($transaction);
 
-    $nft->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->costBasis->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'acquire',
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a send operation', function () {
@@ -40,15 +40,15 @@ it('can handle a send operation', function () {
 
     $transaction = Transaction::factory()->sendNft()->make([
         'date' => LocalDate::parse('2015-10-21'),
-        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+        'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
     ]);
 
     (new NftHandler($this->nftRepository))->handle($transaction);
 
-    $nft->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->proceeds->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where the received asset is a NFT', function () {
@@ -58,15 +58,15 @@ it('can handle a swap operation where the received asset is a NFT', function () 
 
     $transaction = Transaction::factory()->swapToNft()->make([
         'date' => LocalDate::parse('2015-10-21'),
-        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+        'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
     ]);
 
     (new NftHandler($this->nftRepository))->handle($transaction);
 
-    $nft->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->costBasis->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'acquire',
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where the sent asset is a NFT', function () {
@@ -76,15 +76,15 @@ it('can handle a swap operation where the sent asset is a NFT', function () {
 
     $transaction = Transaction::factory()->swapFromNft()->make([
         'date' => LocalDate::parse('2015-10-21'),
-        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+        'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
     ]);
 
     (new NftHandler($this->nftRepository))->handle($transaction);
 
-    $nft->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->proceeds->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where both assets are NFTs', function () {
@@ -94,20 +94,20 @@ it('can handle a swap operation where both assets are NFTs', function () {
 
     $transaction = Transaction::factory()->swapNfts()->make([
         'date' => LocalDate::parse('2015-10-21'),
-        'costBasis' => new FiatAmount('50', FiatCurrency::GBP),
+        'marketValue' => new FiatAmount('50', FiatCurrency::GBP),
     ]);
 
     (new NftHandler($this->nftRepository))->handle($transaction);
 
-    $nft->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->proceeds->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfNft $action) => $action->date->isEqualTo($transaction->date) && $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 
-    $nft->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date)
-            && $action->costBasis->isEqualTo($transaction->costBasis));
+    $nft->shouldHaveReceived(
+        'acquire',
+        fn (AcquireNft $action) => $action->date->isEqualTo($transaction->date) && $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('cannot handle a transaction because the operation is not supported', function () {

--- a/domain/tests/Services/TransactionDispatcher/Handlers/SharePoolingHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/SharePoolingHandlerTest.php
@@ -19,13 +19,14 @@ it('can handle a receive operation', function () {
 
     $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
 
-    $transaction = Transaction::factory()->receive()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->receive()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
 
-    $sharePooling->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'acquire',
+        fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a send operation', function () {
@@ -33,13 +34,14 @@ it('can handle a send operation', function () {
 
     $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
 
-    $transaction = Transaction::factory()->send()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->send()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
 
-    $sharePooling->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where the received asset is not a NFT', function () {
@@ -47,13 +49,14 @@ it('can handle a swap operation where the received asset is not a NFT', function
 
     $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
 
-    $transaction = Transaction::factory()->swapFromNft()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->swapFromNft()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
 
-    $sharePooling->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'acquire',
+        fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where the sent asset is not a NFT', function () {
@@ -61,13 +64,14 @@ it('can handle a swap operation where the sent asset is not a NFT', function () 
 
     $this->sharePoolingRepository->shouldReceive('get')->once()->andReturn($sharePooling);
 
-    $transaction = Transaction::factory()->swapToNft()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->swapToNft()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
 
-    $sharePooling->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('can handle a swap operation where neither asset is a NFT', function () {
@@ -75,17 +79,19 @@ it('can handle a swap operation where neither asset is a NFT', function () {
 
     $this->sharePoolingRepository->shouldReceive('get')->twice()->andReturn($sharePooling);
 
-    $transaction = Transaction::factory()->swap()->make(['costBasis' => new FiatAmount('50', FiatCurrency::GBP)]);
+    $transaction = Transaction::factory()->swap()->make(['marketValue' => new FiatAmount('50', FiatCurrency::GBP)]);
 
     (new SharePoolingHandler($this->sharePoolingRepository))->handle($transaction);
 
-    $sharePooling->shouldHaveReceived('disposeOf')
-        ->once()
-        ->withArgs(fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'disposeOf',
+        fn (DisposeOfSharePoolingToken $action) => $action->proceeds->isEqualTo($transaction->marketValue),
+    )->once();
 
-    $sharePooling->shouldHaveReceived('acquire')
-        ->once()
-        ->withArgs(fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->costBasis));
+    $sharePooling->shouldHaveReceived(
+        'acquire',
+        fn (AcquireSharePoolingToken $action) => $action->costBasis->isEqualTo($transaction->marketValue),
+    )->once();
 });
 
 it('cannot handle a transaction because the operation is not supported', function () {

--- a/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
@@ -20,15 +20,21 @@ it('can handle a transfer operation', function () {
 
     $transaction = Transaction::factory()
         ->transfer()
-        ->withTransactionFee($transactionFee = new FiatAmount('5', FiatCurrency::GBP))
-        ->withExchangeFee($exchangeFee = new FiatAmount('10', FiatCurrency::GBP))
+        ->withNetworkFee($networkFee = new FiatAmount('5', FiatCurrency::GBP))
+        ->withPlatformFee($platformFee = new FiatAmount('10', FiatCurrency::GBP))
         ->make();
 
     (new TransferHandler($this->taxYearRepository))->handle($transaction);
 
-    $taxYear->shouldHaveReceived('recordNonAttributableAllowableCost')
-        ->withArgs(fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($transactionFee))
-        ->withArgs(fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($exchangeFee));
+    $taxYear->shouldHaveReceived(
+        'recordNonAttributableAllowableCost',
+        fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($networkFee),
+    )->once();
+
+    $taxYear->shouldHaveReceived(
+        'recordNonAttributableAllowableCost',
+        fn (RecordNonAttributableAllowableCost $action) => $action->amount->isEqualTo($platformFee),
+    )->once();
 });
 
 it('can handle a transfer operation with no fees', function () {

--- a/domain/tests/Services/TransactionDispatcher/TransactionDispatcherTest.php
+++ b/domain/tests/Services/TransactionDispatcher/TransactionDispatcherTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use Domain\Services\TransactionDispatcher\Handlers\IncomeHandler;
+use Domain\Services\TransactionDispatcher\Handlers\NftHandler;
+use Domain\Services\TransactionDispatcher\Handlers\SharePoolingHandler;
+use Domain\Services\TransactionDispatcher\Handlers\TransferHandler;
+use Domain\Services\TransactionDispatcher\TransactionDispatcher;
+use Domain\ValueObjects\Transaction;
+
+beforeEach(function () {
+    $this->incomeHandler = Mockery::spy(IncomeHandler::class);
+    $this->transferHandler = Mockery::spy(TransferHandler::class);
+    $this->nftHandler = Mockery::spy(NftHandler::class);
+    $this->sharePoolingHandler = Mockery::spy(SharePoolingHandler::class);
+
+    $this->transactionDispatcher = new TransactionDispatcher(
+        $this->incomeHandler,
+        $this->transferHandler,
+        $this->nftHandler,
+        $this->sharePoolingHandler,
+    );
+});
+
+it('can dispatch to the income handler', function () {
+    $transaction = Transaction::factory()->income()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    $this->incomeHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    $this->transferHandler->shouldNotHaveReceived('handle');
+    $this->nftHandler->shouldNotHaveReceived('handle');
+    $this->sharePoolingHandler->shouldHaveReceived('handle')->once()->with($transaction);
+});
+
+it('can dispatch to the transfer handler', function () {
+    $transaction = Transaction::factory()->transfer()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    $this->incomeHandler->shouldNotHaveReceived('handle');
+    $this->transferHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    $this->nftHandler->shouldNotHaveReceived('handle');
+    $this->sharePoolingHandler->shouldNotHaveReceived('handle');
+});
+
+it('can dispatch to the NFT handler', function (string $method, bool $sharePoolingHandler) {
+    $transaction = Transaction::factory()->$method()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    $this->incomeHandler->shouldNotHaveReceived('handle');
+    $this->transferHandler->shouldNotHaveReceived('handle');
+    $this->nftHandler->shouldHaveReceived('handle')->once()->with($transaction);
+
+    if ($sharePoolingHandler) {
+        $this->sharePoolingHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->sharePoolingHandler->shouldNotHaveReceived('handle');
+    }
+})->with([
+    'send NFT' => ['sendNft', true],
+    'receive NFT' => ['receiveNft', true],
+    'acquire NFT' => ['swapToNft', true],
+    'dispose of NFT' => ['swapFromNft', true],
+    'swap NFTs' => ['swapNfts', false],
+]);
+
+it('can dispatch to the share pooling handler', function (string $method, bool $nftHandler) {
+    $transaction = Transaction::factory()->$method()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    if ($method === 'income') {
+        $this->incomeHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->incomeHandler->shouldNotHaveReceived('handle');
+    }
+
+    $this->transferHandler->shouldNotHaveReceived('handle');
+
+    if ($nftHandler) {
+        $this->nftHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->nftHandler->shouldNotHaveReceived('handle');
+    }
+
+    $this->sharePoolingHandler->shouldHaveReceived('handle')->once()->with($transaction);
+})->with([
+    'send' => ['send', false],
+    'receive' => ['receive', false],
+    'swap' => ['swap', false],
+    'income' => ['income', false],
+    'send NFT' => ['sendNft', true],
+    'receive NFT' => ['receiveNft', true],
+    'acquire NFT' => ['swapToNft', true],
+    'dispose of NFT' => ['swapFromNft', true],
+]);
+
+it('can dispatch the transaction fee to the share pooling handler', function (string $method, bool $sharePoolingHandler, bool $nftHandler) {
+    /** @var Transaction */
+    $transaction = Transaction::factory()->$method()->withTransactionFee()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    if ($method === 'income') {
+        $this->incomeHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->incomeHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($method === 'transfer') {
+        $this->transferHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->transferHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($nftHandler) {
+        $this->nftHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->nftHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($sharePoolingHandler) {
+        $this->sharePoolingHandler->shouldHaveReceived('handle')->with($transaction);
+    }
+
+    $this->sharePoolingHandler->shouldHaveReceived('handle')
+        ->withArgs(function (Transaction $feeTransaction) use ($transaction) {
+            return $feeTransaction->isSend()
+                && $feeTransaction->costBasis->isEqualTo($transaction->transactionFeeCostBasis);
+        });
+})->with([
+    'send' => ['send', true, false],
+    'receive' => ['receive', true, false],
+    'swap' => ['swap', true, false],
+    'income' => ['income', true, false],
+    'transfer' => ['transfer', false, false],
+    'send NFT' => ['sendNft', false, true],
+    'receive NFT' => ['receiveNft', false, true],
+    'acquire NFT' => ['swapToNft', false, true],
+    'dispose of NFT' => ['swapFromNft', false, true],
+]);
+
+it('can dispatch the exchange fee to the share pooling handler', function (string $method, bool $sharePoolingHandler, bool $nftHandler) {
+    /** @var Transaction */
+    $transaction = Transaction::factory()->$method()->withExchangeFee()->make();
+
+    $this->transactionDispatcher->dispatch($transaction);
+
+    if ($method === 'income') {
+        $this->incomeHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->incomeHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($method === 'transfer') {
+        $this->transferHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->transferHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($nftHandler) {
+        $this->nftHandler->shouldHaveReceived('handle')->once()->with($transaction);
+    } else {
+        $this->nftHandler->shouldNotHaveReceived('handle');
+    }
+
+    if ($sharePoolingHandler) {
+        $this->sharePoolingHandler->shouldHaveReceived('handle')->with($transaction);
+    }
+
+    $this->sharePoolingHandler->shouldHaveReceived('handle')
+        ->withArgs(function (Transaction $feeTransaction) use ($transaction) {
+            return $feeTransaction->isSend()
+                && $feeTransaction->costBasis->isEqualTo($transaction->exchangeFeeCostBasis);
+        });
+})->with([
+    'send' => ['send', true, false],
+    'receive' => ['receive', true, false],
+    'swap' => ['swap', true, false],
+    'income' => ['income', true, false],
+    'transfer' => ['transfer', false, false],
+    'send NFT' => ['sendNft', false, true],
+    'receive NFT' => ['receiveNft', false, true],
+    'acquire NFT' => ['swapToNft', false, true],
+    'dispose of NFT' => ['swapFromNft', false, true],
+]);


### PR DESCRIPTION
## Summary

This PR introduces the transaction dispatcher.

## Explanation

The dispatcher receives `Transaction` objects in the order they are reported in the spreadsheet and determines to which handlers it should be delegated based on its properties:

* `IncomeHandler`;
* `NftHandler`;
* `SharePoolingHandler`;
* `TransferHandler`.

It also extracts any transaction and/or exchange fees to their own `Transaction` objects so they can be processed as disposals.

The NFT and share pooling handlers attributes the network and platform fees to the disposal or the acquisition depending on the case, or to both in case of a swap, following the [50/50 split rule](https://tech.osteel.me/posts/a-crypto-activity-tracking-tool-part-1-the-domain#fees-in-fiat).

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
