### PR TITLE
Fixes following test involving spreadsheet of real transactions

### DIFF
--- a/app/Services/TransactionProcessor/TransactionProcessor.php
+++ b/app/Services/TransactionProcessor/TransactionProcessor.php
@@ -129,7 +129,7 @@ class TransactionProcessor
 
     private function toFiatAmount(string $value): ?FiatAmount
     {
-        return empty($value) ? null : new FiatAmount($value, FiatCurrency::GBP);
+        return strlen($value) === 0 ? null : new FiatAmount($value, FiatCurrency::GBP);
     }
 
     private function toDate(string $value): LocalDate

--- a/app/Services/TransactionReader/Adapters/PhpSpreadsheetAdapter.php
+++ b/app/Services/TransactionReader/Adapters/PhpSpreadsheetAdapter.php
@@ -6,12 +6,21 @@ namespace App\Services\TransactionReader\Adapters;
 
 use App\Services\TransactionReader\TransactionReader;
 use Generator;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 class PhpSpreadsheetAdapter implements TransactionReader
 {
     public function read(string $path): Generator
     {
+        $stringValueBinder = (new StringValueBinder())->setNumericConversion(false)
+            ->setBooleanConversion(false)
+            ->setNullConversion(false)
+            ->setFormulaConversion(false);
+
+        Cell::setValueBinder($stringValueBinder);
+
         $spreadsheet = IOFactory::load($path);
         $worksheet = $spreadsheet->getActiveSheet()->getRowIterator();
 

--- a/domain/src/Aggregates/Nft/Reactors/NftReactor.php
+++ b/domain/src/Aggregates/Nft/Reactors/NftReactor.php
@@ -28,11 +28,13 @@ final class NftReactor extends EventConsumer
         if ($event->proceeds->isGreaterThan($event->costBasis)) {
             $taxYearAggregate->recordCapitalGain(new RecordCapitalGain(
                 taxYear: $taxYear,
+                date: $event->date,
                 amount: $event->proceeds->minus($event->costBasis),
             ));
         } else {
             $taxYearAggregate->recordCapitalLoss(new RecordCapitalLoss(
                 taxYear: $taxYear,
+                date: $event->date,
                 amount: $event->costBasis->minus($event->proceeds),
             ));
         }

--- a/domain/src/Aggregates/Nft/Reactors/NftReactor.php
+++ b/domain/src/Aggregates/Nft/Reactors/NftReactor.php
@@ -21,7 +21,7 @@ final class NftReactor extends EventConsumer
 
     public function handleNftDisposedOf(NftDisposedOf $event, Message $message): void
     {
-        $taxYear = TaxYearNormaliser::fromYear($event->date->getYear());
+        $taxYear = TaxYearNormaliser::fromDate($event->date);
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenAcquired.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenAcquired.php
@@ -14,16 +14,15 @@ final class SharePoolingTokenAcquired implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string|array<string, string>>> */
+    /** @return array<string, array<string, string|int|null|array<string, string>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_acquisition' => $this->sharePoolingTokenAcquisition->toPayload()];
     }
 
-    /** @param array<string, string|array<string, string|array<string, string>>> $payload */
+    /** @param array<string, array<string, string|array<string, string>>> $payload */
     public static function fromPayload(array $payload): static
     {
-        // @phpstan-ignore-next-line
         return new static(SharePoolingTokenAcquisition::fromPayload($payload['share_pooling_token_acquisition']));
     }
 }

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposalReverted.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposalReverted.php
@@ -14,13 +14,13 @@ final class SharePoolingTokenDisposalReverted implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string|array<string, string|array<string>>>> */
+    /** @return array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
     }
 
-    /** @param array<string, string|array<string, string|array<string, string|array<string>>>> $payload */
+    /** @param array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> $payload */
     public static function fromPayload(array $payload): static
     {
         // @phpstan-ignore-next-line

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposedOf.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposedOf.php
@@ -14,13 +14,13 @@ final class SharePoolingTokenDisposedOf implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string|array<string, string|array<string>>>> */
+    /** @return array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
     }
 
-    /** @param array<string, string|array<string, string|array<string, string|array<string>>>> $payload */
+    /** @param array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> $payload */
     public static function fromPayload(array $payload): static
     {
         // @phpstan-ignore-next-line

--- a/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
+++ b/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
@@ -32,11 +32,13 @@ final class SharePoolingReactor extends EventConsumer
         if ($disposal->proceeds->isGreaterThan($disposal->costBasis)) {
             $taxYearAggregate->recordCapitalGain(new RecordCapitalGain(
                 taxYear: $taxYear,
+                date: $disposal->date,
                 amount: $disposal->proceeds->minus($disposal->costBasis),
             ));
         } else {
             $taxYearAggregate->recordCapitalLoss(new RecordCapitalLoss(
                 taxYear: $taxYear,
+                date: $disposal->date,
                 amount: $disposal->costBasis->minus($disposal->proceeds),
             ));
         }
@@ -54,11 +56,13 @@ final class SharePoolingReactor extends EventConsumer
         if ($disposal->proceeds->isGreaterThan($disposal->costBasis)) {
             $taxYearAggregate->revertCapitalGain(new RevertCapitalGain(
                 taxYear: $taxYear,
+                date: $disposal->date,
                 amount: $disposal->proceeds->minus($disposal->costBasis),
             ));
         } else {
             $taxYearAggregate->revertCapitalLoss(new RevertCapitalLoss(
                 taxYear: $taxYear,
+                date: $disposal->date,
                 amount: $disposal->costBasis->minus($disposal->proceeds),
             ));
         }

--- a/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
+++ b/domain/src/Aggregates/SharePooling/Reactors/SharePoolingReactor.php
@@ -25,7 +25,7 @@ final class SharePoolingReactor extends EventConsumer
     public function handleSharePoolingTokenDisposedOf(SharePoolingTokenDisposedOf $event, Message $message): void
     {
         $disposal = $event->sharePoolingTokenDisposal;
-        $taxYear = TaxYearNormaliser::fromYear($disposal->date->getYear());
+        $taxYear = TaxYearNormaliser::fromDate($disposal->date);
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 
@@ -49,7 +49,7 @@ final class SharePoolingReactor extends EventConsumer
     public function handleSharePoolingTokenDisposalReverted(SharePoolingTokenDisposalReverted $event, Message $message): void
     {
         $disposal = $event->sharePoolingTokenDisposal;
-        $taxYear = TaxYearNormaliser::fromYear($disposal->date->getYear());
+        $taxYear = TaxYearNormaliser::fromDate($disposal->date);
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
@@ -114,19 +114,20 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
             'cost_basis' => $this->costBasis->toPayload(),
             'same_day_quantity' => $this->sameDayQuantity->__toString(),
             'thirty_day_quantity' => $this->thirtyDayQuantity->__toString(),
+            'position' => $this->position,
         ];
     }
 
     /** @param array<string, string|array<string, string>> $payload */
     public static function fromPayload(array $payload): static
     {
-        return new static(
+        return (new static(
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
             new Quantity($payload['quantity']), // @phpstan-ignore-line
             FiatAmount::fromPayload($payload['cost_basis']), // @phpstan-ignore-line
             new Quantity($payload['same_day_quantity']), // @phpstan-ignore-line
             new Quantity($payload['thirty_day_quantity']), // @phpstan-ignore-line
-        );
+        ))->setPosition((int) $payload['position']);
     }
 
     public function __toString(): string

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
@@ -62,11 +62,9 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
     /** Increase the same-day quantity and adjust the 30-day quantity accordingly. */
     public function increaseSameDayQuantity(Quantity $quantity): self
     {
-        //print_r('INCREASE SAME-DAY QUANTITY: '.$quantity->__toString().' (Position: '.$this->position.' | ID: '.spl_object_id($this).')' . "\n");
         // Adjust same-day quantity
         $quantityToAdd = Quantity::minimum($quantity, $this->availableSameDayQuantity());
         $this->sameDayQuantity = $this->sameDayQuantity->plus($quantityToAdd);
-        //print_r($this->sameDayQuantity);
 
         // Adjust 30-day quantity
         $quantityToDeduct = Quantity::minimum($quantityToAdd, $this->thirtyDayQuantity);

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
@@ -62,9 +62,11 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
     /** Increase the same-day quantity and adjust the 30-day quantity accordingly. */
     public function increaseSameDayQuantity(Quantity $quantity): self
     {
+        //print_r('INCREASE SAME-DAY QUANTITY: '.$quantity->__toString().' (Position: '.$this->position.' | ID: '.spl_object_id($this).')' . "\n");
         // Adjust same-day quantity
         $quantityToAdd = Quantity::minimum($quantity, $this->availableSameDayQuantity());
         $this->sameDayQuantity = $this->sameDayQuantity->plus($quantityToAdd);
+        //print_r($this->sameDayQuantity);
 
         // Adjust 30-day quantity
         $quantityToDeduct = Quantity::minimum($quantityToAdd, $this->thirtyDayQuantity);
@@ -105,7 +107,7 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
         return $this;
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string, string|int|null|array<string, string>> */
     public function toPayload(): array
     {
         return [

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
@@ -78,7 +78,7 @@ final class SharePoolingTokenDisposal extends SharePoolingTransaction implements
         return $this->thirtyDayQuantityBreakdown->quantityMatchedWith($acquisition);
     }
 
-    /** @return array<string, string|array<string, string|array<string>>> */
+    /** @return array<string, string|int|bool|null|array<string, string|array<string>>> */
     public function toPayload(): array
     {
         return [

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
@@ -88,20 +88,23 @@ final class SharePoolingTokenDisposal extends SharePoolingTransaction implements
             'proceeds' => $this->proceeds->toPayload(),
             'same_day_quantity_breakdown' => $this->sameDayQuantityBreakdown->toPayload(),
             'thirty_day_quantity_breakdown' => $this->thirtyDayQuantityBreakdown->toPayload(),
+            'processed' => $this->processed,
+            'position' => $this->position,
         ];
     }
 
     /** @param array<string, string|array<string, string|array<string>>> $payload */
     public static function fromPayload(array $payload): static
     {
-        return new static(
+        return (new static(
             LocalDate::parse($payload['date']), // @phpstan-ignore-line
             new Quantity($payload['quantity']), // @phpstan-ignore-line
             FiatAmount::fromPayload($payload['cost_basis']), // @phpstan-ignore-line
             FiatAmount::fromPayload($payload['proceeds']), // @phpstan-ignore-line
             QuantityBreakdown::fromPayload($payload['same_day_quantity_breakdown']), // @phpstan-ignore-line
             QuantityBreakdown::fromPayload($payload['thirty_day_quantity_breakdown']), // @phpstan-ignore-line
-        );
+            (bool) $payload['processed'],
+        ))->setPosition((int) $payload['position']);
     }
 
     public function __toString(): string

--- a/domain/src/Aggregates/TaxYear/Actions/TaxYearAction.php
+++ b/domain/src/Aggregates/TaxYear/Actions/TaxYearAction.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Actions;
 
+use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
 
 abstract class TaxYearAction
 {
     final public function __construct(
         public readonly string $taxYear,
+        public readonly LocalDate $date,
         public readonly FiatAmount $amount,
     ) {
     }

--- a/domain/src/Aggregates/TaxYear/Events/TaxYearEvent.php
+++ b/domain/src/Aggregates/TaxYear/Events/TaxYearEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Events;
 
+use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
@@ -11,6 +12,7 @@ abstract class TaxYearEvent implements SerializablePayload
 {
     final public function __construct(
         public readonly string $taxYear,
+        public readonly LocalDate $date,
         public readonly FiatAmount $amount,
     ) {
     }
@@ -20,6 +22,7 @@ abstract class TaxYearEvent implements SerializablePayload
     {
         return [
             'tax_year' => $this->taxYear,
+            'date' => $this->date->__toString(),
             'amount' => $this->amount->toPayload(),
         ];
     }
@@ -29,6 +32,7 @@ abstract class TaxYearEvent implements SerializablePayload
     {
         return new static(
             $payload['tax_year'], // @phpstan-ignore-line
+            LocalDate::parse($payload['date']), // @phpstan-ignore-line
             FiatAmount::fromPayload($payload['amount']), // @phpstan-ignore-line
         );
     }

--- a/domain/src/Aggregates/TaxYear/Services/TaxYearNormaliser/TaxYearNormaliser.php
+++ b/domain/src/Aggregates/TaxYear/Services/TaxYearNormaliser/TaxYearNormaliser.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Services\TaxYearNormaliser;
 
+use Brick\DateTime\LocalDate;
+
 final class TaxYearNormaliser
 {
-    public static function fromYear(int $year): string
+    private const APRIL = 4;
+
+    public static function fromDate(LocalDate $date): string
     {
+        $year = $date->getYear();
+        $month = $date->getMonth();
+        $day = $date->getDay();
+
+        if ($month < self::APRIL || ($month === self::APRIL && $day < 6)) {
+            --$year;
+        }
+
         return sprintf('%s-%s', $year, $year + 1);
     }
 }

--- a/domain/src/Aggregates/TaxYear/TaxYear.php
+++ b/domain/src/Aggregates/TaxYear/TaxYear.php
@@ -54,6 +54,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new CapitalGainRecorded(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }
@@ -80,6 +81,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new CapitalGainReverted(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }
@@ -103,6 +105,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new CapitalLossRecorded(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }
@@ -130,6 +133,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new CapitalLossReverted(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }
@@ -153,6 +157,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new IncomeRecorded(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }
@@ -175,6 +180,7 @@ class TaxYear implements AggregateRoot
 
         $this->recordThat(new NonAttributableAllowableCostRecorded(
             taxYear: $action->taxYear,
+            date: $action->date,
             amount: $action->amount,
         ));
     }

--- a/domain/src/Enums/FiatCurrency.php
+++ b/domain/src/Enums/FiatCurrency.php
@@ -6,12 +6,14 @@ namespace Domain\Enums;
 
 enum FiatCurrency: string
 {
+    case CAD = 'CAD';
     case GBP = 'GBP';
     case EUR = 'EUR';
 
     public function name(): string
     {
         return match ($this) {
+            FiatCurrency::CAD => 'Canadian dollar',
             FiatCurrency::GBP => 'Pound sterling',
             FiatCurrency::EUR => 'Euro',
         };
@@ -20,6 +22,7 @@ enum FiatCurrency: string
     public function symbol(): string
     {
         return match ($this) {
+            FiatCurrency::CAD => 'C$',
             FiatCurrency::GBP => '£',
             FiatCurrency::EUR => '€',
         };

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -22,7 +22,7 @@ class IncomeHandler
     {
         $this->validate($transaction);
 
-        $taxYear = TaxYearNormaliser::fromYear($transaction->date->getYear());
+        $taxYear = TaxYearNormaliser::fromDate($transaction->date);
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -26,8 +26,11 @@ class IncomeHandler
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 
-        // @phpstan-ignore-next-line
-        $taxYearAggregate->recordIncome(new RecordIncome(taxYear: $taxYear, amount: $transaction->marketValue));
+        $taxYearAggregate->recordIncome(new RecordIncome(
+            taxYear: $taxYear,
+            date: $transaction->date,
+            amount: $transaction->marketValue, // @phpstan-ignore-line
+        ));
 
         $this->taxYearRepository->save($taxYearAggregate);
     }

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -33,6 +33,7 @@ class TransferHandler
         if ($transaction->networkFeeMarketValue?->isGreaterThan('0')) {
             $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
                 taxYear: $taxYear,
+                date: $transaction->date,
                 amount: $transaction->networkFeeMarketValue,
             ));
         }
@@ -40,6 +41,7 @@ class TransferHandler
         if ($transaction->platformFeeMarketValue?->isGreaterThan('0')) {
             $taxYearAggregate->recordNonAttributableAllowableCost(new RecordNonAttributableAllowableCost(
                 taxYear: $taxYear,
+                date: $transaction->date,
                 amount: $transaction->platformFeeMarketValue,
             ));
         }

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -26,7 +26,7 @@ class TransferHandler
             return;
         }
 
-        $taxYear = TaxYearNormaliser::fromYear($transaction->date->getYear());
+        $taxYear = TaxYearNormaliser::fromDate($transaction->date);
         $taxYearId = TaxYearId::fromTaxYear($taxYear);
         $taxYearAggregate = $this->taxYearRepository->get($taxYearId);
 

--- a/domain/src/ValueObjects/Transaction.php
+++ b/domain/src/ValueObjects/Transaction.php
@@ -169,8 +169,7 @@ final class Transaction implements Stringable
         $this->haveAMarketValue($error)
             ->haveASentAsset($error)
             ->haveASentQuantity($error)
-            ->haveAReceivedAsset($error)
-            ->haveAReceivedQuantity($error);
+            ->haveAReceivedAsset($error);
 
         $this->sentAsset !== $this->receivedAsset
             || throw TransactionException::invalidData(sprintf($error, 'have different assets'), $this);

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -1,12 +1,13 @@
 <?php
 
-use Domain\Enums\FiatCurrency;
+use Brick\DateTime\LocalDate;
 use Domain\Aggregates\TaxYear\Events\CapitalGainRecorded;
 use Domain\Aggregates\TaxYear\Events\CapitalGainReverted;
 use Domain\Aggregates\TaxYear\Events\CapitalLossRecorded;
 use Domain\Aggregates\TaxYear\Events\CapitalLossReverted;
 use Domain\Aggregates\TaxYear\Events\IncomeRecorded;
 use Domain\Aggregates\TaxYear\Events\NonAttributableAllowableCostRecorded;
+use Domain\Enums\FiatCurrency;
 use Domain\Tests\Aggregates\TaxYear\Projectors\TaxYearSummaryProjectorTestCase;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\AggregateRootId;
@@ -18,6 +19,7 @@ uses(TaxYearSummaryProjectorTestCase::class);
 it('can handle a capital gain', function () {
     $capitalGainRecorded = new CapitalGainRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -36,6 +38,7 @@ it('can handle a capital gain', function () {
 it('can handle a capital gain reversion', function () {
     $capitalGainReverted = new CapitalGainReverted(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -54,6 +57,7 @@ it('can handle a capital gain reversion', function () {
 it('can handle a capital loss', function () {
     $capitalLossRecorded = new CapitalLossRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -72,6 +76,7 @@ it('can handle a capital loss', function () {
 it('can handle a capital loss reversion', function () {
     $capitalLossReverted = new CapitalLossReverted(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -90,6 +95,7 @@ it('can handle a capital loss reversion', function () {
 it('can handle some income', function () {
     $incomeRecorded = new IncomeRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
@@ -108,6 +114,7 @@ it('can handle some income', function () {
 it('can handle a non-attributable allowable cost', function () {
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 

--- a/domain/tests/Aggregates/TaxYear/TaxYearTest.php
+++ b/domain/tests/Aggregates/TaxYear/TaxYearTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Brick\DateTime\LocalDate;
 use Domain\Aggregates\TaxYear\Actions\RecordCapitalGain;
 use Domain\Aggregates\TaxYear\Actions\RecordCapitalLoss;
 use Domain\Aggregates\TaxYear\Actions\RecordIncome;
@@ -23,11 +24,13 @@ uses(TaxYearTestCase::class);
 it('can record a capital gain', function () {
     $recordCapitalGain = new RecordCapitalGain(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $capitalGainRecorded = new CapitalGainRecorded(
         taxYear: $this->taxYear,
+        date: $recordCapitalGain->date,
         amount: $recordCapitalGain->amount,
     );
 
@@ -39,11 +42,13 @@ it('can record a capital gain', function () {
 it('cannot record a capital gain because the currency is different', function () {
     $capitalGainRecorded = new CapitalGainRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordCapitalGain = new RecordCapitalGain(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -62,16 +67,19 @@ it('cannot record a capital gain because the currency is different', function ()
 it('can revert a capital gain', function () {
     $capitalGainRecorded = new CapitalGainRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $revertCapitalGain = new RevertCapitalGain(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $capitalGainReverted = new CapitalGainReverted(
         taxYear: $this->taxYear,
+        date: $revertCapitalGain->date,
         amount: $revertCapitalGain->amount,
     );
 
@@ -84,6 +92,7 @@ it('can revert a capital gain', function () {
 it('cannot revert a capital gain before a capital gain was recorded', function () {
     $revertCapitalGain = new RevertCapitalGain(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -99,11 +108,13 @@ it('cannot revert a capital gain before a capital gain was recorded', function (
 it('cannot revert a capital gain because the currency is different', function () {
     $capitalGainRecorded = new CapitalGainRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $revertCapitalGain = new RevertCapitalGain(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -122,11 +133,13 @@ it('cannot revert a capital gain because the currency is different', function ()
 it('can record a capital loss', function () {
     $recordCapitalLoss = new RecordCapitalLoss(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $capitalLossRecorded = new CapitalLossRecorded(
         taxYear: $this->taxYear,
+        date: $recordCapitalLoss->date,
         amount: $recordCapitalLoss->amount,
     );
 
@@ -138,11 +151,13 @@ it('can record a capital loss', function () {
 it('cannot record a capital loss because the currency is different', function () {
     $capitalLossRecorded = new CapitalLossRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordCapitalLoss = new RecordCapitalLoss(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -161,16 +176,19 @@ it('cannot record a capital loss because the currency is different', function ()
 it('can revert a capital loss', function () {
     $capitalLossRecorded = new CapitalLossRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $revertCapitalLoss = new RevertCapitalLoss(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $capitalLossReverted = new CapitalLossReverted(
         taxYear: $this->taxYear,
+        date: $revertCapitalLoss->date,
         amount: $revertCapitalLoss->amount,
     );
 
@@ -183,6 +201,7 @@ it('can revert a capital loss', function () {
 it('cannot revert a capital loss before a capital loss was recorded', function () {
     $revertCapitalLoss = new RevertCapitalLoss(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -198,11 +217,13 @@ it('cannot revert a capital loss before a capital loss was recorded', function (
 it('cannot revert a capital loss because the currency is different', function () {
     $capitalLossRecorded = new CapitalLossRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $revertCapitalLoss = new RevertCapitalLoss(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -221,11 +242,13 @@ it('cannot revert a capital loss because the currency is different', function ()
 it('can record some income', function () {
     $recordIncome = new RecordIncome(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $incomeRecorded = new IncomeRecorded(
         taxYear: $this->taxYear,
+        date: $recordIncome->date,
         amount: $recordIncome->amount,
     );
 
@@ -237,11 +260,13 @@ it('can record some income', function () {
 it('cannot record some income because the currency is different', function () {
     $incomeRecorded = new IncomeRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordIncome = new RecordIncome(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 
@@ -260,11 +285,13 @@ it('cannot record some income because the currency is different', function () {
 it('can record a non-attributable allowable cost', function () {
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
         taxYear: $this->taxYear,
+        date: $recordNonAttributableAllowableCost->date,
         amount: $recordNonAttributableAllowableCost->amount,
     );
 
@@ -276,11 +303,13 @@ it('can record a non-attributable allowable cost', function () {
 it('cannot record a non-attributable allowable cost because the currency is different', function () {
     $nonAttributableAllowableCostRecorded = new NonAttributableAllowableCostRecorded(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::GBP),
     );
 
     $recordNonAttributableAllowableCost = new RecordNonAttributableAllowableCost(
         taxYear: $this->taxYear,
+        date: LocalDate::parse('2015-10-21'),
         amount: new FiatAmount('100', FiatCurrency::EUR),
     );
 


### PR DESCRIPTION
## Summary

This PR introduces various changes and fixes following a test processing real transactions.

## Explanation

List of changes:

* Added Canadian dollars to the list of supported fiat currencies;
* `0` amounts are not read as empty values anymore;
* Prevent PhpSpreadsheet from automatically casting values (now preserved as strings);
* The `processed` and `position` attributes of `Transaction` value objects are now also (un)serialised;
* Decreasing the same-day quantity of an acquisition value object now silently fails (see PR and code comments);
* Tax year events now also record the date; and
* The tax year is now properly identified based on the full date, not just the year.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
