### PR TITLE
Refactoring of the Quantity and FiatAmount value objects

### DIFF
--- a/app/Aggregates/Nft/NftServiceProvider.php
+++ b/app/Aggregates/Nft/NftServiceProvider.php
@@ -25,10 +25,8 @@ class NftServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         // @phpstan-ignore-next-line
         $classNameInflector = new ExplicitlyMappedClassNameInflector(config('eventsourcing.class_map'));

--- a/app/Aggregates/SharePooling/SharePoolingServiceProvider.php
+++ b/app/Aggregates/SharePooling/SharePoolingServiceProvider.php
@@ -25,10 +25,8 @@ class SharePoolingServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         // @phpstan-ignore-next-line
         $classNameInflector = new ExplicitlyMappedClassNameInflector(config('eventsourcing.class_map'));

--- a/app/Aggregates/TaxYear/TaxYearServiceProvider.php
+++ b/app/Aggregates/TaxYear/TaxYearServiceProvider.php
@@ -27,10 +27,8 @@ class TaxYearServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton(
             TaxYearSummaryRepositoryInterface::class,

--- a/app/Commands/Process.php
+++ b/app/Commands/Process.php
@@ -26,10 +26,8 @@ class Process extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
-    public function handle(TransactionReader $transactionReader, TransactionProcessor $transactionProcessor)
+    public function handle(TransactionReader $transactionReader, TransactionProcessor $transactionProcessor): int
     {
         $spreadsheet = $this->argument('spreadsheet');
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,10 +14,8 @@ class AppServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton(TransactionReader::class, fn (Application $app) => new PhpSpreadsheetAdapter());
 

--- a/domain/src/Aggregates/Nft/Events/NftAcquired.php
+++ b/domain/src/Aggregates/Nft/Events/NftAcquired.php
@@ -16,7 +16,7 @@ final readonly class NftAcquired implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string,string|array<string,string>> */
     public function toPayload(): array
     {
         return [
@@ -25,7 +25,7 @@ final readonly class NftAcquired implements SerializablePayload
         ];
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new static(

--- a/domain/src/Aggregates/Nft/Events/NftCostBasisIncreased.php
+++ b/domain/src/Aggregates/Nft/Events/NftCostBasisIncreased.php
@@ -16,7 +16,7 @@ final readonly class NftCostBasisIncreased implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string,string|array<string,string>> */
     public function toPayload(): array
     {
         return [
@@ -25,7 +25,7 @@ final readonly class NftCostBasisIncreased implements SerializablePayload
         ];
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new static(

--- a/domain/src/Aggregates/Nft/Events/NftDisposedOf.php
+++ b/domain/src/Aggregates/Nft/Events/NftDisposedOf.php
@@ -17,7 +17,7 @@ final readonly class NftDisposedOf implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string,string|array<string,string>> */
     public function toPayload(): array
     {
         return [
@@ -27,7 +27,7 @@ final readonly class NftDisposedOf implements SerializablePayload
         ];
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new static(

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenAcquired.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenAcquired.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingTokenAcquired implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, array<string, string|int|null|array<string, string>>> */
+    /** @return array<string,array<string,string|int|null|array<string,string>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_acquisition' => $this->sharePoolingTokenAcquisition->toPayload()];
     }
 
-    /** @param array<string, array<string, string|array<string, string>>> $payload */
+    /** @param array<string,array<string,string|array<string,string>>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new static(SharePoolingTokenAcquisition::fromPayload($payload['share_pooling_token_acquisition']));

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposalReverted.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposalReverted.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingTokenDisposalReverted implements SerializablePa
     ) {
     }
 
-    /** @return array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> */
+    /** @return array<string,array<string,string|int|bool|null|array<string,string|array<string>>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
     }
 
-    /** @param array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> $payload */
+    /** @param array<string,array<string,string|int|bool|null|array<string,string|array<string>>>> $payload */
     public static function fromPayload(array $payload): static
     {
         // @phpstan-ignore-next-line

--- a/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposedOf.php
+++ b/domain/src/Aggregates/SharePooling/Events/SharePoolingTokenDisposedOf.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingTokenDisposedOf implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> */
+    /** @return array<string,array<string,string|int|bool|null|array<string,string|array<string>>>> */
     public function toPayload(): array
     {
         return ['share_pooling_token_disposal' => $this->sharePoolingTokenDisposal->toPayload()];
     }
 
-    /** @param array<string, array<string, string|int|bool|null|array<string, string|array<string>>>> $payload */
+    /** @param array<string,array<string,string|int|bool|null|array<string,string|array<string>>>> $payload */
     public static function fromPayload(array $payload): static
     {
         // @phpstan-ignore-next-line

--- a/domain/src/Aggregates/SharePooling/Services/DisposalProcessor/DisposalProcessor.php
+++ b/domain/src/Aggregates/SharePooling/Services/DisposalProcessor/DisposalProcessor.php
@@ -55,7 +55,7 @@ final class DisposalProcessor
     ): FiatAmount {
         assert($transactions->first() !== null);
 
-        $costBasis = $transactions->first()->costBasis->nilAmount();
+        $costBasis = $transactions->first()->costBasis->zero();
 
         return self::processSameDayAcquisitions(
             $transactions,

--- a/domain/src/Aggregates/SharePooling/SharePooling.php
+++ b/domain/src/Aggregates/SharePooling/SharePooling.php
@@ -140,7 +140,7 @@ class SharePooling implements AggregateRoot
         $this->transactions->add($disposal = (new SharePoolingTokenDisposal(
             date: $action->date,
             quantity: $action->quantity,
-            costBasis: $action->proceeds->nilAmount(),
+            costBasis: $action->proceeds->zero(),
             proceeds: $action->proceeds,
             sameDayQuantityBreakdown: new QuantityBreakdown(),
             thirtyDayQuantityBreakdown: new QuantityBreakdown(),

--- a/domain/src/Aggregates/SharePooling/ValueObjects/QuantityBreakdown.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/QuantityBreakdown.php
@@ -12,7 +12,7 @@ final class QuantityBreakdown implements SerializablePayload
 {
     private Quantity $quantity;
 
-    /** @param array<int, Quantity> $breakdown */
+    /** @param array<int,Quantity> $breakdown */
     public function __construct(private array $breakdown = [])
     {
         $this->quantity = array_reduce(
@@ -69,7 +69,7 @@ final class QuantityBreakdown implements SerializablePayload
         return array_keys($this->breakdown);
     }
 
-    /** @return array<string, array<string>> */
+    /** @return array<string,array<string>> */
     public function toPayload(): array
     {
         return [
@@ -77,7 +77,7 @@ final class QuantityBreakdown implements SerializablePayload
         ];
     }
 
-    /** @param array<string, array<string>> $payload */
+    /** @param array<string,array<string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisition.php
@@ -105,7 +105,7 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
         return $this;
     }
 
-    /** @return array<string, string|int|null|array<string, string>> */
+    /** @return array<string,string|int|null|array<string,string>> */
     public function toPayload(): array
     {
         return [
@@ -118,7 +118,7 @@ final class SharePoolingTokenAcquisition extends SharePoolingTransaction impleme
         ];
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return (new static(

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisitions.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisitions.php
@@ -14,7 +14,7 @@ use Traversable;
 /** @implements IteratorAggregate<int, SharePoolingTokenAcquisition> */
 final class SharePoolingTokenAcquisitions implements IteratorAggregate
 {
-    /** @param array<int, SharePoolingTokenAcquisition> $acquisitions */
+    /** @param array<int,SharePoolingTokenAcquisition> $acquisitions */
     private function __construct(private array $acquisitions = [])
     {
     }
@@ -76,7 +76,7 @@ final class SharePoolingTokenAcquisitions implements IteratorAggregate
         return array_reduce(
             $this->acquisitions,
             fn (FiatAmount $total, SharePoolingTokenAcquisition $acquisition) => $total->plus($acquisition->costBasis),
-            $this->acquisitions[0]->costBasis->nilAmount(),
+            $this->acquisitions[0]->costBasis->zero(),
         );
     }
 
@@ -106,13 +106,13 @@ final class SharePoolingTokenAcquisitions implements IteratorAggregate
         );
 
         if (empty($section104PoolAcquisitions)) {
-            $this->acquisitions[0]->costBasis->nilAmount();
+            $this->acquisitions[0]->costBasis->zero();
         }
 
         return array_reduce(
             $section104PoolAcquisitions,
             fn (FiatAmount $total, SharePoolingTokenAcquisition $acquisition) => $total->plus($acquisition->section104PoolCostBasis()),
-            $this->acquisitions[0]->costBasis->nilAmount(),
+            $this->acquisitions[0]->costBasis->zero(),
         );
     }
 

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposal.php
@@ -48,7 +48,7 @@ final class SharePoolingTokenDisposal extends SharePoolingTransaction implements
         return (new SharePoolingTokenDisposal(
             date: $this->date,
             quantity: $this->quantity,
-            costBasis: $this->costBasis->nilAmount(),
+            costBasis: $this->costBasis->zero(),
             proceeds: $this->proceeds,
             sameDayQuantityBreakdown: new QuantityBreakdown(),
             thirtyDayQuantityBreakdown: new QuantityBreakdown(),
@@ -78,7 +78,7 @@ final class SharePoolingTokenDisposal extends SharePoolingTransaction implements
         return $this->thirtyDayQuantityBreakdown->quantityMatchedWith($acquisition);
     }
 
-    /** @return array<string, string|int|bool|null|array<string, string|array<string>>> */
+    /** @return array<string,string|int|bool|null|array<string,string|array<string>>> */
     public function toPayload(): array
     {
         return [
@@ -93,7 +93,7 @@ final class SharePoolingTokenDisposal extends SharePoolingTransaction implements
         ];
     }
 
-    /** @param array<string, string|array<string, string|array<string>>> $payload */
+    /** @param array<string,string|array<string,string|array<string>>> $payload */
     public static function fromPayload(array $payload): static
     {
         return (new static(

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposals.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposals.php
@@ -13,7 +13,7 @@ use Traversable;
 /** @implements IteratorAggregate<int, SharePoolingTokenDisposal> */
 final class SharePoolingTokenDisposals implements IteratorAggregate
 {
-    /** @param array<int, SharePoolingTokenDisposal> $disposals */
+    /** @param array<int,SharePoolingTokenDisposal> $disposals */
     private function __construct(private array $disposals = [])
     {
     }

--- a/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTransactions.php
+++ b/domain/src/Aggregates/SharePooling/ValueObjects/SharePoolingTransactions.php
@@ -14,7 +14,7 @@ use Traversable;
 /** @implements IteratorAggregate<int, SharePoolingTransaction> */
 final class SharePoolingTransactions implements IteratorAggregate
 {
-    /** @param array<int, SharePoolingTransaction> $transactions */
+    /** @param array<int,SharePoolingTransaction> $transactions */
     private function __construct(private array $transactions = [])
     {
     }

--- a/domain/src/Aggregates/TaxYear/Events/CapitalEvent.php
+++ b/domain/src/Aggregates/TaxYear/Events/CapitalEvent.php
@@ -18,7 +18,7 @@ abstract class CapitalEvent extends TaxYearEvent
     ) {
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string,string|array<string,string>> */
     public function toPayload(): array
     {
         return array_merge(parent::toPayload(), [
@@ -27,7 +27,7 @@ abstract class CapitalEvent extends TaxYearEvent
         ]);
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         return new static(

--- a/domain/src/Aggregates/TaxYear/Events/TaxYearEvent.php
+++ b/domain/src/Aggregates/TaxYear/Events/TaxYearEvent.php
@@ -17,7 +17,7 @@ abstract class TaxYearEvent implements SerializablePayload
     ) {
     }
 
-    /** @return array<string, string|array<string, string>> */
+    /** @return array<string,string|array<string,string>> */
     public function toPayload(): array
     {
         return [
@@ -27,7 +27,7 @@ abstract class TaxYearEvent implements SerializablePayload
         ];
     }
 
-    /** @param array<string, string|array<string, string>> $payload */
+    /** @param array<string,string|array<string,string>> $payload */
     public static function fromPayload(array $payload): static
     {
         // @phpstan-ignore-next-line

--- a/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
+++ b/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
@@ -107,7 +107,7 @@ final class TaxYearSummary extends Model
     {
         return Attribute::make(
             get: fn (string $value) => TaxYearId::fromString($value),
-            set: fn ($value) => $value instanceof TaxYearId ? $value->toString() : $value,
+            set: fn (mixed $value) => $value instanceof TaxYearId ? $value->toString() : $value,
         );
     }
 
@@ -122,7 +122,7 @@ final class TaxYearSummary extends Model
     protected function capitalGain(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
             set: fn (FiatAmount $value) => $value->amount,
         );
     }
@@ -130,7 +130,7 @@ final class TaxYearSummary extends Model
     protected function capitalCostBasis(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
             set: fn (FiatAmount $value) => $value->amount,
         );
     }
@@ -138,7 +138,7 @@ final class TaxYearSummary extends Model
     protected function capitalProceeds(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
             set: fn (FiatAmount $value) => $value->amount,
         );
     }
@@ -146,7 +146,7 @@ final class TaxYearSummary extends Model
     protected function income(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
             set: fn (FiatAmount $value) => $value->amount,
         );
     }
@@ -154,7 +154,7 @@ final class TaxYearSummary extends Model
     protected function nonAttributableAllowableCosts(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => new FiatAmount($value ?? '0', $this->currency),
+            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
             set: fn (FiatAmount $value) => $value->amount,
         );
     }

--- a/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
+++ b/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
@@ -107,7 +107,7 @@ final class TaxYearSummary extends Model
     {
         return Attribute::make(
             get: fn (string $value) => TaxYearId::fromString($value),
-            set: fn (mixed $value) => $value instanceof TaxYearId ? $value->toString() : $value,
+            set: fn (TaxYearId|string $value) => $value instanceof TaxYearId ? $value->toString() : $value,
         );
     }
 
@@ -122,40 +122,40 @@ final class TaxYearSummary extends Model
     protected function capitalGain(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
-            set: fn (FiatAmount $value) => $value->amount,
+            get: fn (?string $value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => (string) $value->quantity,
         );
     }
 
     protected function capitalCostBasis(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
-            set: fn (FiatAmount $value) => $value->amount,
+            get: fn (?string $value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => (string) $value->quantity,
         );
     }
 
     protected function capitalProceeds(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
-            set: fn (FiatAmount $value) => $value->amount,
+            get: fn (?string $value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => (string) $value->quantity,
         );
     }
 
     protected function income(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
-            set: fn (FiatAmount $value) => $value->amount,
+            get: fn (?string $value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => (string) $value->quantity,
         );
     }
 
     protected function nonAttributableAllowableCosts(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => new FiatAmount($value ?? '0', $this->currency),
-            set: fn (FiatAmount $value) => $value->amount,
+            get: fn (?string $value) => new FiatAmount($value ?? '0', $this->currency),
+            set: fn (FiatAmount $value) => (string) $value->quantity,
         );
     }
 }

--- a/domain/src/Aggregates/TaxYear/TaxYear.php
+++ b/domain/src/Aggregates/TaxYear/TaxYear.php
@@ -120,7 +120,7 @@ class TaxYear implements AggregateRoot
     {
         $this->currency ??= $event->amount->currency;
         $this->capitalGainOrLoss = $this->capitalGainOrLoss?->minus($event->amount)
-            ?? $event->amount->nilAmount()->minus($event->amount);
+            ?? $event->amount->zero()->minus($event->amount);
     }
 
     public function revertCapitalLoss(RevertCapitalLoss $action): void

--- a/domain/src/Services/TransactionDispatcher/Handlers/Traits/AttributesFees.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/Traits/AttributesFees.php
@@ -13,7 +13,7 @@ trait AttributesFees
     {
         $amount = $transaction->hasNetworkFee()
             ? $transaction->networkFeeMarketValue
-            : $transaction->marketValue->nilAmount(); // @phpstan-ignore-line
+            : $transaction->marketValue->zero(); // @phpstan-ignore-line
 
         if ($transaction->hasPlatformFee()) {
             $amount = $amount->plus($transaction->platformFeeMarketValue); // @phpstan-ignore-line

--- a/domain/src/ValueObjects/Exceptions/QuantityException.php
+++ b/domain/src/ValueObjects/Exceptions/QuantityException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\ValueObjects\Exceptions;
+
+use RuntimeException;
+
+final class QuantityException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidQuantity(string $quantity): self
+    {
+        return new self(sprintf(
+            'Invalid quantity %s – the value must be a string representing a positive or negative integer or decimal amount, e.g. "-1.23456789"',
+            $quantity,
+        ));
+    }
+}

--- a/domain/src/ValueObjects/Quantity.php
+++ b/domain/src/ValueObjects/Quantity.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Domain\ValueObjects;
 
 use Domain\Services\Math\Math;
+use Domain\ValueObjects\Exceptions\QuantityException;
 use Stringable;
 
 final readonly class Quantity implements Stringable
 {
+    /** @throws QuantityException */
     public function __construct(public string $quantity)
     {
+        if (preg_match('/^[+-]?\d+(\.\d+)?$/', $quantity) !== 1) {
+            throw QuantityException::invalidQuantity($quantity);
+        }
     }
 
     public static function zero(): Quantity
@@ -33,59 +38,79 @@ final readonly class Quantity implements Stringable
         return new Quantity($this->quantity);
     }
 
+    public function isPositive(): bool
+    {
+        return Math::gte($this->quantity, '0');
+    }
+
+    public function isNegative(): bool
+    {
+        return Math::lt($this->quantity, '0');
+    }
+
     public function isZero(): bool
     {
         return Math::eq($this->quantity, '0');
     }
 
+    /** @throws QuantityException */
     public function isEqualTo(Quantity | string $quantity): bool
     {
-        return Math::eq($this->quantity, $this->extractValue($quantity));
+        return Math::eq($this->quantity, $this->toQuantity($quantity)->quantity);
     }
 
+    /** @throws QuantityException */
     public function isGreaterThan(Quantity | string $quantity): bool
     {
-        return Math::gt($this->quantity, $this->extractValue($quantity));
+        return Math::gt($this->quantity, $this->toQuantity($quantity)->quantity);
     }
 
+    /** @throws QuantityException */
     public function isGreaterThanOrEqualTo(Quantity | string $quantity): bool
     {
-        return Math::gte($this->quantity, $this->extractValue($quantity));
+        return Math::gte($this->quantity, $this->toQuantity($quantity)->quantity);
     }
 
+    /** @throws QuantityException */
     public function isLessThan(Quantity | string $quantity): bool
     {
-        return Math::lt($this->quantity, $this->extractValue($quantity));
+        return Math::lt($this->quantity, $this->toQuantity($quantity)->quantity);
     }
 
+    /** @throws QuantityException */
     public function isLessThanOrEqualTo(Quantity | string $quantity): bool
     {
-        return Math::lte($this->quantity, $this->extractValue($quantity));
+        return Math::lte($this->quantity, $this->toQuantity($quantity)->quantity);
     }
 
+    /** @throws QuantityException */
     public function plus(Quantity | string $quantity): Quantity
     {
-        return new Quantity(Math::add($this->quantity, $this->extractValue($quantity)));
+        return new Quantity(Math::add($this->quantity, $this->toQuantity($quantity)->quantity));
     }
 
+    /** @throws QuantityException */
     public function minus(Quantity | string $quantity): Quantity
     {
-        return new Quantity(Math::sub($this->quantity, $this->extractValue($quantity)));
+        return new Quantity(Math::sub($this->quantity, $this->toQuantity($quantity)->quantity));
     }
 
+    /** @throws QuantityException */
     public function multipliedBy(Quantity | string $quantity): Quantity
     {
-        return new Quantity(Math::mul($this->quantity, $this->extractValue($quantity)));
+        return new Quantity(Math::mul($this->quantity, $this->toQuantity($quantity)->quantity));
     }
 
+    /** @throws QuantityException */
     public function dividedBy(Quantity | string $quantity): Quantity
     {
-        return new Quantity(Math::div($this->quantity, $this->extractValue($quantity)));
+        return new Quantity(Math::div($this->quantity, $this->toQuantity($quantity)->quantity));
     }
 
-    private function extractValue(Quantity | string $quantity): string
+    /** @throws QuantityException */
+    private function toQuantity(Quantity | string $quantity): Quantity
     {
-        return $quantity instanceof Quantity ? $quantity->quantity : $quantity;
+        return $quantity instanceof Quantity ? $quantity : new self($quantity);
     }
 
     public function __toString(): string

--- a/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisitionsTest.php
+++ b/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTokenAcquisitionsTest.php
@@ -23,7 +23,7 @@ it('can make a collection of one acquisition', function () {
 });
 
 it('can make a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make(),
         SharePoolingTokenAcquisition::factory()->make(),
@@ -103,7 +103,7 @@ it('can return the average cost basis per unit of a collection of acquisitions',
 ]);
 
 it('can return the section 104 pool quantity of a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'quantity' => new Quantity('100'),
@@ -132,7 +132,7 @@ it('can return the section 104 pool quantity of a collection of acquisitions', f
 });
 
 it('can return the section 104 pool cost basis of a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -165,7 +165,7 @@ it('can return the section 104 pool cost basis of a collection of acquisitions',
 });
 
 it('can return the average section 104 pool cost basis per unit of a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -198,7 +198,7 @@ it('can return the average section 104 pool cost basis per unit of a collection 
 });
 
 it('can return the acquisitions with available same-day quantity from a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -232,7 +232,7 @@ it('can return the acquisitions with available same-day quantity from a collecti
 });
 
 it('can return the available same-day quantity from a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -263,7 +263,7 @@ it('can return the available same-day quantity from a collection of acquisitions
 });
 
 it('can return the acquisitions with available 30-day quantity from a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -296,7 +296,7 @@ it('can return the acquisitions with available 30-day quantity from a collection
 });
 
 it('can return the acquisitions with 30-day quantity from a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenAcquisition> */
+    /** @var list<SharePoolingTokenAcquisition> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),

--- a/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposalsTest.php
+++ b/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTokenDisposalsTest.php
@@ -24,7 +24,7 @@ it('can make a collection of one disposal', function () {
 });
 
 it('can make a collection of disposals', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         SharePoolingTokenDisposal::factory()->make(),
         SharePoolingTokenDisposal::factory()->make(),
@@ -47,7 +47,7 @@ it('can add a disposal to a collection of disposals', function () {
 });
 
 it('can reverse a collection of disposals', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         $disposal1 = SharePoolingTokenDisposal::factory()->make(),
         $disposal2 = SharePoolingTokenDisposal::factory()->make(),
@@ -63,7 +63,7 @@ it('can reverse a collection of disposals', function () {
 });
 
 it('can return the unprocessed disposals from a collection of disposals', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         SharePoolingTokenDisposal::factory()->make(),
         $unprocessed1 = SharePoolingTokenDisposal::factory()->unprocessed()->make(),
@@ -79,7 +79,7 @@ it('can return the unprocessed disposals from a collection of disposals', functi
 });
 
 it('can return the disposals with available same-day quantity from a collection of disposals', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         SharePoolingTokenDisposal::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -113,7 +113,7 @@ it('can return the disposals with available same-day quantity from a collection 
 });
 
 it('can return the available same-day quantity from a collection of disposals', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         SharePoolingTokenDisposal::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),
@@ -144,7 +144,7 @@ it('can return the available same-day quantity from a collection of disposals', 
 });
 
 it('can return the acquisitions with available 30-day quantity from a collection of acquisitions', function () {
-    /** @var array<int, SharePoolingTokenDisposal> */
+    /** @var list<SharePoolingTokenDisposal> */
     $items = [
         SharePoolingTokenDisposal::factory()->make([
             'costBasis' => new FiatAmount('100', FiatCurrency::GBP),

--- a/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTransactionsTest.php
+++ b/domain/tests/Aggregates/SharePooling/ValueObjects/SharePoolingTransactionsTest.php
@@ -26,7 +26,7 @@ it('can make a collection of one transaction', function () {
 });
 
 it('can make a collection of transactions', function () {
-    /** @var array<int, SharePoolingTransaction> */
+    /** @var list<SharePoolingTransaction> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make(),
         SharePoolingTokenDisposal::factory()->make(),
@@ -40,7 +40,7 @@ it('can make a collection of transactions', function () {
 });
 
 it('can return the first transaction of a collection', function () {
-    /** @var array<int, SharePoolingTransaction> */
+    /** @var list<SharePoolingTransaction> */
     $items = [
         $first = SharePoolingTokenAcquisition::factory()->make(),
         SharePoolingTokenDisposal::factory()->make(),
@@ -53,7 +53,7 @@ it('can return the first transaction of a collection', function () {
 });
 
 it('can return a transaction at a position from the collection', function () {
-    /** @var array<int, SharePoolingTransaction> */
+    /** @var list<SharePoolingTransaction> */
     $items = [
         SharePoolingTokenAcquisition::factory()->make(),
         $second = SharePoolingTokenDisposal::factory()->make(),
@@ -75,7 +75,7 @@ it('can add a transaction to a collection of transactions', function () {
 });
 
 it('can return the processed transactions from the collection', function () {
-    /** @var array<int, SharePoolingTransaction> */
+    /** @var list<SharePoolingTransaction> */
     $items = [
         $processed1 = SharePoolingTokenAcquisition::factory()->make(),
         SharePoolingTokenDisposal::factory()->unprocessed()->make(),

--- a/domain/tests/Factories/ValueObjects/TransactionFactory.php
+++ b/domain/tests/Factories/ValueObjects/TransactionFactory.php
@@ -174,7 +174,7 @@ class TransactionFactory extends PlainObjectFactory
     {
         return $this->state([
             'networkFeeCurrency' => $marketValue?->currency->value ?? FiatCurrency::GBP->value,
-            'networkFeeQuantity' => new Quantity($marketValue?->amount ?? '10'),
+            'networkFeeQuantity' => $marketValue?->quantity ?? new Quantity('10'),
             'networkFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
         ]);
     }
@@ -192,7 +192,7 @@ class TransactionFactory extends PlainObjectFactory
     {
         return $this->state([
             'platformFeeCurrency' => $marketValue?->currency->value ?? FiatCurrency::GBP->value,
-            'platformFeeQuantity' => new Quantity($marketValue?->amount ?? '10'),
+            'platformFeeQuantity' => $marketValue?->quantity ?? new Quantity('10'),
             'platformFeeMarketValue' => $marketValue ?? new FiatAmount('10', FiatCurrency::GBP),
         ]);
     }

--- a/domain/tests/ValueObjects/FiatAmountTest.php
+++ b/domain/tests/ValueObjects/FiatAmountTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\Exceptions\FiatAmountException;
+use Domain\ValueObjects\Exceptions\QuantityException;
+use Domain\ValueObjects\FiatAmount;
+
+it('cannot instantiate a fiat amount', function () {
+    expect(fn () => new FiatAmount('foo', FiatCurrency::GBP))
+        ->toThrow(QuantityException::class, QuantityException::invalidQuantity('foo')->getMessage());
+});
+
+it('can instantiate a fiat amount', function () {
+    expect((string) (new FiatAmount('10', FiatCurrency::GBP))->quantity)->toBe('10');
+});
+
+it('can instantiate a fiat amount with a zero quantity', function () {
+    $amount = (new FiatAmount('10', FiatCurrency::GBP))->zero();
+
+    expect($amount->quantity->isZero())->toBeTrue();
+    $this->assertEquals($amount->currency, FiatCurrency::GBP);
+});
+
+it('can tell whether a fiat amount is positive', function (string $quantity, bool $result) {
+    expect((new FiatAmount($quantity, FiatCurrency::GBP))->isPositive())->toBe($result);
+})->with([
+    'scenario 1' => ['1', true],
+    'scenario 2' => ['-1', false],
+    'scenario 3' => ['0', true],
+    'scenario 4' => ['-0', true],
+]);
+
+it('can tell whether a fiat amount is negative', function (string $quantity, bool $result) {
+    expect((new FiatAmount($quantity, FiatCurrency::GBP))->isNegative())->toBe($result);
+})->with([
+    'scenario 1' => ['1', false],
+    'scenario 2' => ['-1', true],
+    'scenario 3' => ['0', false],
+    'scenario 4' => ['-0', false],
+]);
+
+it('can tell whether a fiat amount is zero', function (string $quantity, bool $result) {
+    expect((new FiatAmount($quantity, FiatCurrency::GBP))->isZero())->toBe($result);
+})->with([
+    'scenario 1' => ['0', true],
+    'scenario 2' => ['1', false],
+    'scenario 3' => ['-1', false],
+    'scenario 4' => ['-0', true],
+]);
+
+it('can tell whether two quantities are equal', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))->isEqualTo($quantity2))->toBe($result);
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->isEqualTo(new FiatAmount($quantity2, FiatCurrency::GBP)))
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can tell whether a fiat amount is greater than another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))->isGreaterThan($quantity2))->toBe($result);
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->isGreaterThan(new FiatAmount($quantity2, FiatCurrency::GBP)))
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', false],
+    'scenario 2' => ['1', '0', true],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', false],
+    'scenario 5' => ['0', '-0', false],
+]);
+
+it('can tell whether a fiat amount is greater than or equal to another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))->isGreaterThanOrEqualTo($quantity2))->toBe($result);
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->isGreaterThanOrEqualTo(new FiatAmount($quantity2, FiatCurrency::GBP)))
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', true],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can tell whether a fiat amount is less than another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))->isLessThan($quantity2))->toBe($result);
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->isLessThan(new FiatAmount($quantity2, FiatCurrency::GBP)))
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', false],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', true],
+    'scenario 4' => ['-1', '-1', false],
+    'scenario 5' => ['0', '-0', false],
+]);
+
+it('can tell whether a fiat amount is less than or equal to another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))->isLessThanOrEqualTo($quantity2))->toBe($result);
+    expect((new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->isLessThanOrEqualTo(new FiatAmount($quantity2, FiatCurrency::GBP)))
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', true],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can add a fiat amount to another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))->plus($quantity2)->quantity)->toBe($result);
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->plus(new FiatAmount($quantity2, FiatCurrency::GBP))->quantity)
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '2'],
+    'scenario 2' => ['-1', '-1', '-2'],
+    'scenario 3' => ['0', '0', '0'],
+    'scenario 4' => ['-0', '-0', '0'],
+]);
+
+it('can subtract a fiat amount from another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))->minus($quantity2)->quantity)->toBe($result);
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->minus(new FiatAmount($quantity2, FiatCurrency::GBP))->quantity)
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '0'],
+    'scenario 2' => ['-1', '1', '-2'],
+    'scenario 3' => ['-1', '-1', '0'],
+    'scenario 4' => ['0', '0', '0'],
+    'scenario 5' => ['-0', '-0', '0'],
+]);
+
+it('can multiply a fiat amount by another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))->multipliedBy($quantity2)->quantity)->toBe($result);
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->multipliedBy(new FiatAmount($quantity2, FiatCurrency::GBP))->quantity)
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '1'],
+    'scenario 2' => ['2', '2', '4'],
+    'scenario 3' => ['-1', '2', '-2'],
+    'scenario 4' => ['-1', '-1', '1'],
+    'scenario 5' => ['0', '0', '0'],
+    'scenario 6' => ['-0', '-0', '0'],
+]);
+
+it('can divide a fiat amount by another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))->dividedBy($quantity2)->quantity)->toBe($result);
+    expect((string) (new FiatAmount($quantity1, FiatCurrency::GBP))
+        ->dividedBy(new FiatAmount($quantity2, FiatCurrency::GBP))->quantity)
+        ->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '1'],
+    'scenario 2' => ['2', '2', '1'],
+    'scenario 3' => ['-2', '2', '-1'],
+    'scenario 4' => ['-1', '-1', '1'],
+]);
+
+it('cannot perform a fiat amount operation because the currencies do not match', function (string $operation) {
+    expect(fn () => (new FiatAmount('10', FiatCurrency::GBP))->$operation(new FiatAmount('10', FiatCurrency::EUR)))->toThrow(
+        FiatAmountException::class,
+        FiatAmountException::fiatCurrenciesDoNotMatch(FiatCurrency::GBP->value, FiatCurrency::EUR->value)->getMessage(),
+    );
+})->with([
+    'isEqualTo',
+    'isGreaterThan',
+    'isGreaterThanOrEqualTo',
+    'isLessThan',
+    'isLessThanOrEqualTo',
+    'plus',
+    'minus',
+    'multipliedBy',
+    'dividedBy',
+]);
+
+it('can express a fiat amount as a string', function () {
+    expect((string) (new FiatAmount('10', FiatCurrency::GBP)))->toBe('£10');
+});

--- a/domain/tests/ValueObjects/QuantityTest.php
+++ b/domain/tests/ValueObjects/QuantityTest.php
@@ -4,14 +4,15 @@ use Domain\ValueObjects\Exceptions\QuantityException;
 use Domain\ValueObjects\Quantity;
 
 it('cannot instantiate a quantity', function (string $quantity) {
-    new Quantity($quantity);
+    expect(fn () => new Quantity($quantity))
+        ->toThrow(QuantityException::class, QuantityException::invalidQuantity($quantity)->getMessage());
 })->with([
     'not a number' => 'foo',
     'mixed number and string 1' => '12345foo',
     'mixed number and string 2' => 'foo12345',
     'invalid format' => '.01234',
     'invalid sign' => '~1234',
-])->throws(QuantityException::class);
+]);
 
 it('can instantiate a quantity', function (string $quantity) {
     expect((new Quantity($quantity))->quantity)->toBe($quantity);

--- a/domain/tests/ValueObjects/QuantityTest.php
+++ b/domain/tests/ValueObjects/QuantityTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use Domain\ValueObjects\Exceptions\QuantityException;
+use Domain\ValueObjects\Quantity;
+
+it('cannot instantiate a quantity', function (string $quantity) {
+    new Quantity($quantity);
+})->with([
+    'not a number' => 'foo',
+    'mixed number and string 1' => '12345foo',
+    'mixed number and string 2' => 'foo12345',
+    'invalid format' => '.01234',
+    'invalid sign' => '~1234',
+])->throws(QuantityException::class);
+
+it('can instantiate a quantity', function (string $quantity) {
+    expect((new Quantity($quantity))->quantity)->toBe($quantity);
+})->with([
+    '1',
+    '0',
+    '-1',
+    '-0',
+    '1.2345',
+    '-1.2345',
+    '-0.000000000000012345',
+]);
+
+it('can instantiate a zero quantity', function () {
+    expect(Quantity::zero()->quantity)->toBe('0');
+});
+
+it('can return the greatest value', function (string $quantity1, string $quantity2, string $result) {
+    expect(Quantity::maximum(new Quantity($quantity1), new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '2', '2'],
+    'scenario 2' => ['2', '1', '2'],
+    'scenario 3' => ['1', '1', '1'],
+    'scenario 4' => ['1', '-2', '1'],
+]);
+
+it('can return the lowest value', function (string $quantity1, string $quantity2, string $result) {
+    expect(Quantity::minimum(new Quantity($quantity1), new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '2', '1'],
+    'scenario 2' => ['2', '1', '1'],
+    'scenario 3' => ['1', '1', '1'],
+    'scenario 4' => ['1', '-2', '-2'],
+]);
+
+it('can copy a quantity', function (string $quantity) {
+    $quantity1 = new Quantity($quantity);
+    $quantity2 = $quantity1->copy();
+
+    expect($quantity2->quantity)->toBe($quantity1->quantity);
+    expect($quantity2)->not->toBe($quantity1);
+})->with(['1', '-1']);
+
+it('can tell whether a quantity is positive', function (string $quantity, bool $result) {
+    expect((new Quantity($quantity))->isPositive())->toBe($result);
+})->with([
+    'scenario 1' => ['1', true],
+    'scenario 2' => ['-1', false],
+    'scenario 3' => ['0', true],
+    'scenario 4' => ['-0', true],
+]);
+
+it('can tell whether a quantity is negative', function (string $quantity, bool $result) {
+    expect((new Quantity($quantity))->isNegative())->toBe($result);
+})->with([
+    'scenario 1' => ['1', false],
+    'scenario 2' => ['-1', true],
+    'scenario 3' => ['0', false],
+    'scenario 4' => ['-0', false],
+]);
+
+it('can tell whether a quantity is zero', function (string $quantity, bool $result) {
+    expect((new Quantity($quantity))->isZero())->toBe($result);
+})->with([
+    'scenario 1' => ['0', true],
+    'scenario 2' => ['1', false],
+    'scenario 3' => ['-1', false],
+    'scenario 4' => ['-0', true],
+]);
+
+it('can tell whether two quantities are equal', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new Quantity($quantity1))->isEqualTo($quantity2))->toBe($result);
+    expect((new Quantity($quantity1))->isEqualTo(new Quantity($quantity2)))->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can tell whether a quantity is greater than another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new Quantity($quantity1))->isGreaterThan($quantity2))->toBe($result);
+    expect((new Quantity($quantity1))->isGreaterThan(new Quantity($quantity2)))->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', false],
+    'scenario 2' => ['1', '0', true],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', false],
+    'scenario 5' => ['0', '-0', false],
+]);
+
+it('can tell whether a quantity is greater than or equal to another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new Quantity($quantity1))->isGreaterThanOrEqualTo($quantity2))->toBe($result);
+    expect((new Quantity($quantity1))->isGreaterThanOrEqualTo(new Quantity($quantity2)))->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', true],
+    'scenario 3' => ['0', '1', false],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can tell whether a quantity is less than another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new Quantity($quantity1))->isLessThan($quantity2))->toBe($result);
+    expect((new Quantity($quantity1))->isLessThan(new Quantity($quantity2)))->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', false],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', true],
+    'scenario 4' => ['-1', '-1', false],
+    'scenario 5' => ['0', '-0', false],
+]);
+
+it('can tell whether a quantity is less than or equal to another one', function (string $quantity1, string $quantity2, bool $result) {
+    expect((new Quantity($quantity1))->isLessThanOrEqualTo($quantity2))->toBe($result);
+    expect((new Quantity($quantity1))->isLessThanOrEqualTo(new Quantity($quantity2)))->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', true],
+    'scenario 2' => ['1', '0', false],
+    'scenario 3' => ['0', '1', true],
+    'scenario 4' => ['-1', '-1', true],
+    'scenario 5' => ['0', '-0', true],
+]);
+
+it('can add a quantity to another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((new Quantity($quantity1))->plus($quantity2)->quantity)->toBe($result);
+    expect((new Quantity($quantity1))->plus(new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '2'],
+    'scenario 2' => ['-1', '-1', '-2'],
+    'scenario 3' => ['0', '0', '0'],
+    'scenario 4' => ['-0', '-0', '0'],
+]);
+
+it('can subtract a quantity from another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((new Quantity($quantity1))->minus($quantity2)->quantity)->toBe($result);
+    expect((new Quantity($quantity1))->minus(new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '0'],
+    'scenario 2' => ['-1', '1', '-2'],
+    'scenario 3' => ['-1', '-1', '0'],
+    'scenario 4' => ['0', '0', '0'],
+    'scenario 5' => ['-0', '-0', '0'],
+]);
+
+it('can multiply a quantity by another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((new Quantity($quantity1))->multipliedBy($quantity2)->quantity)->toBe($result);
+    expect((new Quantity($quantity1))->multipliedBy(new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '1'],
+    'scenario 2' => ['2', '2', '4'],
+    'scenario 3' => ['-1', '2', '-2'],
+    'scenario 4' => ['-1', '-1', '1'],
+    'scenario 5' => ['0', '0', '0'],
+    'scenario 6' => ['-0', '-0', '0'],
+]);
+
+it('can divide a quantity by another one', function (string $quantity1, string $quantity2, string $result) {
+    expect((new Quantity($quantity1))->dividedBy($quantity2)->quantity)->toBe($result);
+    expect((new Quantity($quantity1))->dividedBy(new Quantity($quantity2))->quantity)->toBe($result);
+})->with([
+    'scenario 1' => ['1', '1', '1'],
+    'scenario 2' => ['2', '2', '1'],
+    'scenario 3' => ['-2', '2', '-1'],
+    'scenario 4' => ['-1', '-1', '1'],
+]);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
 	checkMissingCallableSignature: true
 
 	type_coverage:
-		return_type: 98
-		param_type: 98
+		return_type: 100
+		param_type: 100
 		property_type: 100
+		print_suggestions: true


### PR DESCRIPTION
## Summary

This PR improves the `Quantity` and `FiatAmount` value objects, laying the groundwork for further refactoring.

## Explanation

The `Quantity` class' constructor now validates the passed value against a regular expression, allowing it to be a string representation of a positive or negative integer or decimal number.

`FiatAmount` objects now hold a `Quantity $quantity` property instead of `string $amount`.

Both value objects are now covered by unit tests.

The PR also adds a few missing argument and return types as to reach [100% coverage](https://github.com/osteel/dime/pull/24), and cleans up a few array structure declarations.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
