### PR TITLE
Put the asset in all aggregate events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
 
       - name: Install composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@v2
 
       - name: Check coding style
         run: vendor/bin/pint --test
@@ -37,27 +37,10 @@ jobs:
         uses: shivammathur/setup-php@v2
 
       - name: Install composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@v2
 
       - name: Analyse code
         run: vendor/bin/phpstan
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-
-      - name: Install composer dependencies
-        uses: "ramsey/composer-install@v2"
-
-      - name: Check test coverage
-        run: vendor/bin/pest --ci --coverage
 
   tests:
     name: Tests
@@ -83,9 +66,9 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependency-versions }}
 
       - name: Run test suite
-        run: vendor/bin/pest
+        run: vendor/bin/pest --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
 
       - name: Install composer dependencies
         uses: ramsey/composer-install@v2

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Yannick Chenot
+Copyright (c) 2023 Yannick Chenot
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ramsey/uuid": "^4.7.3"
     },
     "require-dev": {
-        "eventsauce/test-utilities": "dev-main",
+        "eventsauce/test-utilities": "^3.3",
         "fakerphp/faker": "^1.21.0",
         "intonate/tinker-zero": "^1.2",
         "laravel/pint": "^1.6",
@@ -68,7 +68,7 @@
     "scripts": {
         "pint": "pint",
         "stan": "phpstan",
-        "test": "pest",
+        "test": "pest --coverage",
         "all": [
             "@pint",
             "@stan",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "intonate/tinker-zero": "^1.2",
         "laravel/pint": "^1.6",
         "mockery/mockery": "^1.5.1",
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^2.5",
         "pestphp/pest-plugin-mock": "^2.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.10.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "962e885074055b62ad319a126315a311",
+    "content-hash": "d0e242c9fb239d8fb6c73403bb930c99",
     "packages": [
         {
             "name": "brick/date-time",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "932bbc2e1add3342b2a9e375fe24220a",
+    "content-hash": "962e885074055b62ad319a126315a311",
     "packages": [
         {
             "name": "brick/date-time",
@@ -5278,7 +5278,7 @@
         },
         {
             "name": "eventsauce/test-utilities",
-            "version": "dev-main",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EventSaucePHP/TestUtilities.git",
@@ -5295,7 +5295,6 @@
                 "php": "^8.0",
                 "phpunit/phpunit": "^8.5|^9.4|^10.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -5319,7 +5318,7 @@
             ],
             "description": "Test utilities for EventSauce.",
             "support": {
-                "source": "https://github.com/EventSaucePHP/TestUtilities/tree/main"
+                "source": "https://github.com/EventSaucePHP/TestUtilities/tree/3.3.0"
             },
             "funding": [
                 {
@@ -8406,9 +8405,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "eventsauce/test-utilities": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
@@ -48,12 +48,6 @@ final readonly class AcquireNonFungibleAsset implements Stringable, WithAsset
 
     public function __toString(): string
     {
-        return sprintf(
-            '%s (asset: %s, date: %s, cost basis: %s)',
-            self::class,
-            (string) $this->asset,
-            (string) $this->date,
-            (string) $this->costBasis,
-        );
+        return sprintf('%s (asset: %s, date: %s, cost basis: %s)', self::class, $this->asset, $this->date, $this->costBasis);
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
@@ -11,8 +11,9 @@ use Domain\Aggregates\NonFungibleAsset\ValueObjects\NonFungibleAssetId;
 use Domain\Services\ActionRunner\ActionRunner;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
+use Stringable;
 
-final readonly class AcquireNonFungibleAsset implements WithAsset
+final readonly class AcquireNonFungibleAsset implements Stringable, WithAsset
 {
     public function __construct(
         public Asset $asset,
@@ -43,5 +44,16 @@ final readonly class AcquireNonFungibleAsset implements WithAsset
     public function getAsset(): Asset
     {
         return $this->asset;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '%s (asset: %s, date: %s, cost basis: %s)',
+            self::class,
+            (string) $this->asset,
+            (string) $this->date,
+            (string) $this->costBasis,
+        );
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Domain\Aggregates\NonFungibleAsset\Actions;
 
 use Brick\DateTime\LocalDate;
+use Domain\Aggregates\NonFungibleAsset\Actions\Contracts\WithAsset;
 use Domain\Aggregates\NonFungibleAsset\Repositories\NonFungibleAssetRepository;
 use Domain\Aggregates\NonFungibleAsset\ValueObjects\NonFungibleAssetId;
 use Domain\Services\ActionRunner\ActionRunner;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 
-final readonly class AcquireNonFungibleAsset
+final readonly class AcquireNonFungibleAsset implements WithAsset
 {
     public function __construct(
-        private Asset $asset,
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $costBasis,
     ) {
@@ -37,5 +38,10 @@ final readonly class AcquireNonFungibleAsset
 
         $nonFungibleAsset->acquire($this);
         $nonFungibleAssetRepository->save($nonFungibleAsset);
+    }
+
+    public function getAsset(): Asset
+    {
+        return $this->asset;
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/Contracts/WithAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/Contracts/WithAsset.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Aggregates\NonFungibleAsset\Actions\Contracts;
+
+use Domain\ValueObjects\Asset;
+
+interface WithAsset
+{
+    public function getAsset(): Asset;
+}

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
@@ -6,16 +6,17 @@ namespace Domain\Aggregates\NonFungibleAsset\Actions;
 
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\NonFungibleAsset\Actions\Contracts\Timely;
+use Domain\Aggregates\NonFungibleAsset\Actions\Contracts\WithAsset;
 use Domain\Aggregates\NonFungibleAsset\Repositories\NonFungibleAssetRepository;
 use Domain\Aggregates\NonFungibleAsset\ValueObjects\NonFungibleAssetId;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Stringable;
 
-final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely
+final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely, WithAsset
 {
     public function __construct(
-        private Asset $asset,
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $proceeds,
     ) {
@@ -28,6 +29,11 @@ final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely
 
         $nonFungibleAsset->disposeOf($this);
         $nonFungibleAssetRepository->save($nonFungibleAsset);
+    }
+
+    public function getAsset(): Asset
+    {
+        return $this->asset;
     }
 
     public function getDate(): LocalDate

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
@@ -43,6 +43,12 @@ final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely, Wi
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, proceeds: %s)', self::class, (string) $this->date, (string) $this->proceeds);
+        return sprintf(
+            '%s (asset: %s, date: %s, proceeds: %s)',
+            self::class,
+            (string) $this->asset,
+            (string) $this->date,
+            (string) $this->proceeds,
+        );
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
@@ -43,12 +43,6 @@ final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely, Wi
 
     public function __toString(): string
     {
-        return sprintf(
-            '%s (asset: %s, date: %s, proceeds: %s)',
-            self::class,
-            (string) $this->asset,
-            (string) $this->date,
-            (string) $this->proceeds,
-        );
+        return sprintf('%s (asset: %s, date: %s, proceeds: %s)', self::class, $this->asset, $this->date, $this->proceeds);
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
@@ -44,8 +44,9 @@ final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Ti
     public function __toString(): string
     {
         return sprintf(
-            '%s (date: %s, cost basis increase: %s)',
+            '%s (asset: %s, date: %s, cost basis increase: %s)',
             self::class,
+            (string) $this->asset,
             (string) $this->date,
             (string) $this->costBasisIncrease,
         );

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
@@ -46,9 +46,9 @@ final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Ti
         return sprintf(
             '%s (asset: %s, date: %s, cost basis increase: %s)',
             self::class,
-            (string) $this->asset,
-            (string) $this->date,
-            (string) $this->costBasisIncrease,
+            $this->asset,
+            $this->date,
+            $this->costBasisIncrease,
         );
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
@@ -6,16 +6,17 @@ namespace Domain\Aggregates\NonFungibleAsset\Actions;
 
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\NonFungibleAsset\Actions\Contracts\Timely;
+use Domain\Aggregates\NonFungibleAsset\Actions\Contracts\WithAsset;
 use Domain\Aggregates\NonFungibleAsset\Repositories\NonFungibleAssetRepository;
 use Domain\Aggregates\NonFungibleAsset\ValueObjects\NonFungibleAssetId;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Stringable;
 
-final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Timely
+final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Timely, WithAsset
 {
     public function __construct(
-        private Asset $asset,
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $costBasisIncrease,
     ) {
@@ -28,6 +29,11 @@ final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Ti
 
         $nonFungibleAsset->increaseCostBasis($this);
         $nonFungibleAssetRepository->save($nonFungibleAsset);
+    }
+
+    public function getAsset(): Asset
+    {
+        return $this->asset;
     }
 
     public function getDate(): LocalDate

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetAcquired.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetAcquired.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
 use Brick\DateTime\LocalDate;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final readonly class NonFungibleAssetAcquired implements SerializablePayload
 {
     public function __construct(
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $costBasis,
     ) {
     }
 
-    /** @return array{date:string,cost_basis:array{quantity:string,currency:string}} */
+    /** @return array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis:array{quantity:string,currency:string}} */
     public function toPayload(): array
     {
         return [
+            'asset' => $this->asset->toPayload(),
             'date' => (string) $this->date,
             'cost_basis' => $this->costBasis->toPayload(),
         ];
     }
 
-    /** @param array{date:string,cost_basis:array{quantity:string,currency:string}} $payload */
+    /** @param array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis:array{quantity:string,currency:string}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(
+            Asset::fromPayload($payload['asset']),
             LocalDate::parse($payload['date']),
             FiatAmount::fromPayload($payload['cost_basis']),
         );

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
 use Brick\DateTime\LocalDate;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final readonly class NonFungibleAssetCostBasisIncreased implements SerializablePayload
 {
     public function __construct(
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $costBasisIncrease,
     ) {
     }
 
-    /** @return array{date:string,cost_basis_increase:array{quantity:string,currency:string}} */
+    /** @return array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis_increase:array{quantity:string,currency:string}} */
     public function toPayload(): array
     {
         return [
+            'asset' => $this->asset->toPayload(),
             'date' => (string) $this->date,
             'cost_basis_increase' => $this->costBasisIncrease->toPayload(),
         ];
     }
 
-    /** @param array{date:string,cost_basis_increase:array{quantity:string,currency:string}} $payload */
+    /** @param array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis_increase:array{quantity:string,currency:string}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(
+            Asset::fromPayload($payload['asset']),
             LocalDate::parse($payload['date']),
             FiatAmount::fromPayload($payload['cost_basis_increase']),
         );

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetDisposedOf.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetDisposedOf.php
@@ -5,32 +5,36 @@ declare(strict_types=1);
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
 use Brick\DateTime\LocalDate;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final readonly class NonFungibleAssetDisposedOf implements SerializablePayload
 {
     public function __construct(
+        public Asset $asset,
         public LocalDate $date,
         public FiatAmount $costBasis,
         public FiatAmount $proceeds,
     ) {
     }
 
-    /** @return array{date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} */
+    /** @return array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} */
     public function toPayload(): array
     {
         return [
+            'asset' => $this->asset->toPayload(),
             'date' => (string) $this->date,
             'cost_basis' => $this->costBasis->toPayload(),
             'proceeds' => $this->proceeds->toPayload(),
         ];
     }
 
-    /** @param array{date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} $payload */
+    /** @param array{asset:array{symbol:string,is_non_fungible:string},date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(
+            Asset::fromPayload($payload['asset']),
             LocalDate::parse($payload['date']),
             FiatAmount::fromPayload($payload['cost_basis']),
             FiatAmount::fromPayload($payload['proceeds']),

--- a/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
@@ -23,6 +23,16 @@ final class NonFungibleAssetException extends RuntimeException
         return new self(sprintf('Non-fungible asset %s has already been acquired', (string) $asset));
     }
 
+    public static function assetMismatch(Asset $current, Stringable&WithAsset $action): self
+    {
+        return new self(sprintf(
+            'Cannot process this non-fungible asset %s transaction because the assets don\'t match (incoming: %s): %s',
+            (string) $current,
+            (string) $action->getAsset(),
+            (string) $action,
+        ));
+    }
+
     public static function olderThanPreviousTransaction(
         Stringable&WithAsset $action,
         LocalDate $previousTransactionDate,
@@ -41,7 +51,7 @@ final class NonFungibleAssetException extends RuntimeException
         FiatCurrency $incoming,
     ): self {
         return new self(sprintf(
-            'Cannot process this %s non-fungible asset transaction because the currencies don\'t match (current: %s; incoming: %s): %s',
+            'Cannot process this non-fungible asset %s transaction because the currencies don\'t match (current: %s; incoming: %s): %s',
             (string) $action->getAsset(),
             $current?->name() ?? 'undefined',
             $incoming->name(),

--- a/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
@@ -23,6 +23,15 @@ final class NonFungibleAssetException extends RuntimeException
         return new self(sprintf('Non-fungible asset %s has already been acquired', (string) $asset));
     }
 
+    public static function assetIsFungible(Stringable&WithAsset $action): self
+    {
+        return new self(sprintf(
+            'Cannot process this non-fungible asset %s transaction because the asset is fungible: %s',
+            (string) $action->getAsset(),
+            (string) $action,
+        ));
+    }
+
     public static function assetMismatch(Asset $current, Stringable&WithAsset $action): self
     {
         return new self(sprintf(

--- a/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Exceptions/NonFungibleAssetException.php
@@ -27,8 +27,8 @@ final class NonFungibleAssetException extends RuntimeException
     {
         return new self(sprintf(
             'Cannot process this non-fungible asset %s transaction because the asset is fungible: %s',
-            (string) $action->getAsset(),
-            (string) $action,
+            $action->getAsset(),
+            $action,
         ));
     }
 
@@ -36,9 +36,9 @@ final class NonFungibleAssetException extends RuntimeException
     {
         return new self(sprintf(
             'Cannot process this non-fungible asset %s transaction because the assets don\'t match (incoming: %s): %s',
-            (string) $current,
-            (string) $action->getAsset(),
-            (string) $action,
+            $current,
+            $action->getAsset(),
+            $action,
         ));
     }
 
@@ -48,9 +48,9 @@ final class NonFungibleAssetException extends RuntimeException
     ): self {
         return new self(sprintf(
             'This non-fungible asset %s transaction appears to be older than the previous one (%s): %s',
-            (string) $action->getAsset(),
-            (string) $previousTransactionDate,
-            (string) $action,
+            $action->getAsset(),
+            $previousTransactionDate,
+            $action,
         ));
     }
 
@@ -61,10 +61,10 @@ final class NonFungibleAssetException extends RuntimeException
     ): self {
         return new self(sprintf(
             'Cannot process this non-fungible asset %s transaction because the currencies don\'t match (current: %s; incoming: %s): %s',
-            (string) $action->getAsset(),
+            $action->getAsset(),
             $current?->name() ?? 'undefined',
             $incoming->name(),
-            (string) $action,
+            $action,
         ));
     }
 
@@ -72,12 +72,12 @@ final class NonFungibleAssetException extends RuntimeException
     {
         return new self(sprintf(
             'Cannot increase the cost basis of non-fungible asset %s as it has not been acquired',
-            (string) $asset,
+            $asset,
         ));
     }
 
     public static function cannotDisposeOfBeforeAcquisition(Asset $asset): self
     {
-        return new self(sprintf('Cannot dispose of non-fungible asset %s as it has not been acquired', (string) $asset));
+        return new self(sprintf('Cannot dispose of non-fungible asset %s as it has not been acquired', $asset));
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
@@ -74,6 +74,7 @@ class NonFungibleAsset implements AggregateRoot
         $this->isAlreadyAcquired()
             || throw NonFungibleAssetException::cannotIncreaseCostBasisBeforeAcquisition($action->asset);
 
+        $this->validateAsset($action);
         $this->validateCurrency($action, $action->costBasisIncrease->currency);
         $this->validateTimeline($action);
 
@@ -97,6 +98,7 @@ class NonFungibleAsset implements AggregateRoot
     {
         $this->isAlreadyAcquired() || throw NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($action->asset);
 
+        $this->validateAsset($action);
         $this->validateTimeline($action);
 
         assert(! is_null($this->costBasis));
@@ -114,6 +116,16 @@ class NonFungibleAsset implements AggregateRoot
         $this->asset = null;
         $this->costBasis = null;
         $this->previousTransactionDate = null;
+    }
+
+    /** @throws NonFungibleAssetException */
+    private function validateAsset(Stringable&WithAsset $action): void
+    {
+        if (is_null($this->asset) || $action->getAsset()->is($this->asset)) {
+            return;
+        }
+
+        throw NonFungibleAssetException::assetMismatch(current: $this->asset, action: $action);
     }
 
     /** @throws NonFungibleAssetException */

--- a/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
@@ -54,6 +54,8 @@ class NonFungibleAsset implements AggregateRoot
     {
         $this->isAlreadyAcquired() === false || throw NonFungibleAssetException::alreadyAcquired($action->asset);
 
+        $this->validateAsset($action);
+
         $this->recordThat(new NonFungibleAssetAcquired(
             asset: $action->asset,
             date: $action->date,
@@ -121,11 +123,13 @@ class NonFungibleAsset implements AggregateRoot
     /** @throws NonFungibleAssetException */
     private function validateAsset(Stringable&WithAsset $action): void
     {
-        if (is_null($this->asset) || $action->getAsset()->is($this->asset)) {
-            return;
+        if (is_null($this->asset) && ! $action->getAsset()->isNonFungible) {
+            throw NonFungibleAssetException::assetIsFungible($action);
         }
 
-        throw NonFungibleAssetException::assetMismatch(current: $this->asset, action: $action);
+        if ($this->asset !== null && ! $action->getAsset()->is($this->asset)) {
+            throw NonFungibleAssetException::assetMismatch(current: $this->asset, action: $action);
+        }
     }
 
     /** @throws NonFungibleAssetException */

--- a/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
@@ -101,6 +101,7 @@ class NonFungibleAsset implements AggregateRoot
         $this->isAlreadyAcquired() || throw NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($action->asset);
 
         $this->validateAsset($action);
+        $this->validateCurrency($action, $action->proceeds->currency);
         $this->validateTimeline($action);
 
         assert(! is_null($this->costBasis));

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
@@ -49,11 +49,12 @@ final readonly class AcquireSharePoolingAsset implements Stringable, Timely, Wit
     public function __toString(): string
     {
         return sprintf(
-            '%s (date: %s, quantity: %s, cost basis: %s)',
+            '%s (asset: %s, date: %s, quantity: %s, cost basis: %s)',
             self::class,
-            (string) $this->date,
-            (string) $this->quantity,
-            (string) $this->costBasis,
+            $this->asset,
+            $this->date,
+            $this->quantity,
+            $this->costBasis,
         );
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
@@ -6,6 +6,7 @@ namespace Domain\Aggregates\SharePoolingAsset\Actions;
 
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\Actions\Contracts\Timely;
+use Domain\Aggregates\SharePoolingAsset\Actions\Contracts\WithAsset;
 use Domain\Aggregates\SharePoolingAsset\Repositories\SharePoolingAssetRepository;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetId;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
@@ -14,7 +15,7 @@ use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 use Stringable;
 
-final readonly class AcquireSharePoolingAsset implements Stringable, Timely
+final readonly class AcquireSharePoolingAsset implements Stringable, Timely, WithAsset
 {
     public function __construct(
         public Asset $asset,
@@ -33,6 +34,11 @@ final readonly class AcquireSharePoolingAsset implements Stringable, Timely
 
         $sharePoolingAsset->acquire($this);
         $sharePoolingAssetRepository->save($sharePoolingAsset);
+    }
+
+    public function getAsset(): Asset
+    {
+        return $this->asset;
     }
 
     public function getDate(): LocalDate

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/Contracts/WithAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/Contracts/WithAsset.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Aggregates\SharePoolingAsset\Actions\Contracts;
+
+use Domain\ValueObjects\Asset;
+
+interface WithAsset
+{
+    public function getAsset(): Asset;
+}

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
@@ -6,6 +6,7 @@ namespace Domain\Aggregates\SharePoolingAsset\Actions;
 
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\Actions\Contracts\Timely;
+use Domain\Aggregates\SharePoolingAsset\Actions\Contracts\WithAsset;
 use Domain\Aggregates\SharePoolingAsset\Repositories\SharePoolingAssetRepository;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetId;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
@@ -14,7 +15,7 @@ use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 use Stringable;
 
-final readonly class DisposeOfSharePoolingAsset implements Stringable, Timely
+final readonly class DisposeOfSharePoolingAsset implements Stringable, Timely, WithAsset
 {
     public function __construct(
         public Asset $asset,
@@ -38,6 +39,11 @@ final readonly class DisposeOfSharePoolingAsset implements Stringable, Timely
     public function isReplay(): bool
     {
         return ! is_null($this->transactionId);
+    }
+
+    public function getAsset(): Asset
+    {
+        return $this->asset;
     }
 
     public function getDate(): LocalDate

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
@@ -54,11 +54,12 @@ final readonly class DisposeOfSharePoolingAsset implements Stringable, Timely, W
     public function __toString(): string
     {
         return sprintf(
-            '%s (date: %s, quantity: %s, proceeds: %s)',
+            '%s (asset: %s, date: %s, quantity: %s, proceeds: %s)',
             self::class,
-            (string) $this->date,
-            (string) $this->quantity,
-            (string) $this->proceeds,
+            $this->asset,
+            $this->date,
+            $this->quantity,
+            $this->proceeds,
         );
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
@@ -6,6 +6,7 @@ namespace Domain\Aggregates\SharePoolingAsset\Entities;
 
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -18,6 +19,7 @@ abstract class SharePoolingAssetTransaction implements Stringable
     public readonly SharePoolingAssetTransactionId $id;
 
     public function __construct(
+        public readonly Asset $asset,
         public readonly LocalDate $date,
         public readonly Quantity $quantity,
         public readonly FiatAmount $costBasis,

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetAcquired.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetAcquired.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingAssetAcquired implements SerializablePayload
     ) {
     }
 
-    /** @return array{share_pooling_asset_acquisition:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} */
+    /** @return array{share_pooling_asset_acquisition:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} */
     public function toPayload(): array
     {
         return ['share_pooling_asset_acquisition' => $this->acquisition->toPayload()];
     }
 
-    /** @param array{share_pooling_asset_acquisition:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} $payload */
+    /** @param array{share_pooling_asset_acquisition:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(SharePoolingAssetAcquisition::fromPayload($payload['share_pooling_asset_acquisition']));

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposalReverted.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposalReverted.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingAssetDisposalReverted implements SerializablePa
     ) {
     }
 
-    /** @return array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
+    /** @return array{share_pooling_asset_disposal:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
     public function toPayload(): array
     {
         return ['share_pooling_asset_disposal' => $this->disposal->toPayload()];
     }
 
-    /** @param array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
+    /** @param array{share_pooling_asset_disposal:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(SharePoolingAssetDisposal::fromPayload($payload['share_pooling_asset_disposal']));

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposedOf.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposedOf.php
@@ -14,13 +14,13 @@ final readonly class SharePoolingAssetDisposedOf implements SerializablePayload
     ) {
     }
 
-    /** @return array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
+    /** @return array{share_pooling_asset_disposal:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
     public function toPayload(): array
     {
         return ['share_pooling_asset_disposal' => $this->disposal->toPayload()];
     }
 
-    /** @param array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
+    /** @param array{share_pooling_asset_disposal:array{id:string,asset:array{symbol:string,is_non_fungible:string},date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
     public static function fromPayload(array $payload): static
     {
         return new self(SharePoolingAssetDisposal::fromPayload($payload['share_pooling_asset_disposal']));

--- a/domain/src/Aggregates/SharePoolingAsset/Exceptions/SharePoolingAssetException.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Exceptions/SharePoolingAssetException.php
@@ -23,9 +23,9 @@ final class SharePoolingAssetException extends RuntimeException
     {
         return new self(sprintf(
             'Cannot process this share pooling asset %s transaction because the assets don\'t match (incoming: %s): %s',
-            (string) $action->getAsset(),
-            (string) $incoming,
-            (string) $action,
+            $action->getAsset(),
+            $incoming,
+            $action,
         ));
     }
 
@@ -36,10 +36,10 @@ final class SharePoolingAssetException extends RuntimeException
     ): self {
         return new self(sprintf(
             'Cannot process this share pooling asset %s transaction because the currencies don\'t match (current: %s; incoming: %s): %s',
-            (string) $action->getAsset(),
+            $action->getAsset(),
             $current?->name() ?? 'undefined',
             $incoming->name(),
-            (string) $action,
+            $action,
         ));
     }
 
@@ -49,9 +49,9 @@ final class SharePoolingAssetException extends RuntimeException
     ): self {
         return new self(sprintf(
             'This share pooling asset %s transaction appears to be older than the previous one (%s): %s',
-            (string) $action->getAsset(),
-            (string) $previousTransactionDate,
-            (string) $action,
+            $action->getAsset(),
+            $previousTransactionDate,
+            $action,
         ));
     }
 

--- a/domain/src/Aggregates/SharePoolingAsset/Services/DisposalProcessor/DisposalProcessor.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Services/DisposalProcessor/DisposalProcessor.php
@@ -36,6 +36,7 @@ final class DisposalProcessor
         // Disposals being replayed must keep the same ID so they are inserted back in the right place
         return new SharePoolingAssetDisposal(
             id: $disposal->transactionId,
+            asset: $disposal->asset,
             date: $disposal->date,
             quantity: $disposal->quantity,
             costBasis: $costBasis,

--- a/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
@@ -253,7 +253,7 @@ class SharePoolingAsset implements AggregateRoot
     }
 
     /** @throws SharePoolingAssetException */
-    private function validateTimeline(Timely&Stringable $action): void
+    private function validateTimeline(Stringable&Timely $action): void
     {
         if (is_null($this->previousTransactionDate) || $action->getDate()->isAfterOrEqualTo($this->previousTransactionDate)) {
             return;

--- a/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
+++ b/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
@@ -29,11 +29,6 @@ final class RevertCapitalGainUpdate implements Stringable
 
     public function __toString(): string
     {
-        return sprintf(
-            '%s (date: %s, capital gain: (%s))',
-            self::class,
-            (string) $this->date,
-            (string) $this->capitalGain,
-        );
+        return sprintf('%s (date: %s, capital gain: (%s))', self::class, $this->date, $this->capitalGain);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
@@ -29,11 +29,6 @@ final class UpdateCapitalGain implements Stringable
 
     public function __toString(): string
     {
-        return sprintf(
-            '%s (date: %s, capital gain: (%s))',
-            self::class,
-            (string) $this->date,
-            (string) $this->capitalGain,
-        );
+        return sprintf('%s (date: %s, capital gain: (%s))', self::class, $this->date, $this->capitalGain);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
@@ -29,11 +29,6 @@ final class UpdateIncome implements Stringable
 
     public function __toString(): string
     {
-        return sprintf(
-            '%s (date: %s, income: %s)',
-            self::class,
-            (string) $this->date,
-            (string) $this->income,
-        );
+        return sprintf('%s (date: %s, income: %s)', self::class, $this->date, $this->income);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
@@ -32,8 +32,8 @@ final class UpdateNonAttributableAllowableCost implements Stringable
         return sprintf(
             '%s (date: %s, non-attributable allowable cost: %s)',
             self::class,
-            (string) $this->date,
-            (string) $this->nonAttributableAllowableCost,
+            $this->date,
+            $this->nonAttributableAllowableCost,
         );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Exceptions/TaxYearException.php
+++ b/domain/src/Aggregates/TaxYear/Exceptions/TaxYearException.php
@@ -25,7 +25,7 @@ final class TaxYearException extends RuntimeException
             'Cannot process this %s tax year action because incoming tax year %s doesn\'t match: %s',
             $taxYearId->toString(),
             $incomingTaxYear,
-            (string) $action,
+            $action,
         ));
     }
 
@@ -40,7 +40,7 @@ final class TaxYearException extends RuntimeException
             $taxYearId->toString(),
             $current?->name() ?? 'undefined',
             $incoming->name(),
-            (string) $action,
+            $action,
         ));
     }
 

--- a/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
@@ -79,6 +79,6 @@ final readonly class CapitalGain implements JsonSerializable, SerializablePayloa
 
     public function __toString(): string
     {
-        return sprintf('cost basis: %s, proceeds: %s', (string) $this->costBasis, (string) $this->proceeds);
+        return sprintf('cost basis: %s, proceeds: %s', $this->costBasis, $this->proceeds);
     }
 }

--- a/domain/src/ValueObjects/Asset.php
+++ b/domain/src/ValueObjects/Asset.php
@@ -25,6 +25,11 @@ final readonly class Asset implements SerializablePayload, Stringable
         }
     }
 
+    public static function nonFungible(string $symbol): self
+    {
+        return new self(symbol: $symbol, isNonFungible: true);
+    }
+
     public function is(Asset $asset): bool
     {
         return $asset->symbol === $this->symbol && $asset->isNonFungible === $this->isNonFungible;

--- a/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
@@ -42,6 +42,24 @@ it('can acquire a non-fungible asset', function () {
         ->then($nonFungibleAssetAcquired);
 });
 
+it('cannot acquire a non-fungible asset because the asset is fungible', function () {
+    // When
+
+    $acquireNonFungibleAsset = new AcquireNonFungibleAsset(
+        asset: new Asset('FOO'),
+        date: LocalDate::parse('2015-10-21'),
+        costBasis: FiatAmount::GBP('100'),
+    );
+
+    // Then
+
+    $assetIsFungible = NonFungibleAssetException::assetIsFungible($acquireNonFungibleAsset);
+
+    /** @var AggregateRootTestCase $this */
+    $this->when($acquireNonFungibleAsset)
+        ->expectToFail($assetIsFungible);
+});
+
 it('cannot acquire the same non-fungible asset more than once', function () {
     // Given
 

--- a/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
@@ -307,6 +307,37 @@ it('cannot dispose of a non-fungible asset because the assets don\'t match', fun
         ->expectToFail($cannotIncreaseCostBasis);
 });
 
+it('cannot dispose of a non-fungible asset because the currencies don\'t match', function () {
+    // Given
+
+    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
+        date: LocalDate::parse('2015-10-21'),
+        costBasis: FiatAmount::GBP('100'),
+    );
+
+    // When
+
+    $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
+        asset: $this->asset,
+        date: LocalDate::parse('2015-10-21'),
+        proceeds: new FiatAmount('100', FiatCurrency::EUR),
+    );
+
+    // Then
+
+    $cannotIncreaseCostBasis = NonFungibleAssetException::currencyMismatch(
+        action: $disposeOfNonFungibleAsset,
+        current: FiatCurrency::GBP,
+        incoming: FiatCurrency::EUR,
+    );
+
+    /** @var AggregateRootTestCase $this */
+    $this->given($nonFungibleAssetAcquired)
+        ->when($disposeOfNonFungibleAsset)
+        ->expectToFail($cannotIncreaseCostBasis);
+});
+
 it('cannot dispose of a non-fungible asset because the transaction is older than the previous one', function () {
     // Given
 

--- a/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
@@ -16,11 +16,15 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 uses(NonFungibleAssetTestCase::class);
 
+beforeEach(function () {
+    $this->asset = new Asset(symbol: 'foo', isNonFungible: true);
+});
+
 it('can acquire a non-fungible asset', function () {
     // When
 
     $acquireNonFungibleAsset = new AcquireNonFungibleAsset(
-        asset: new Asset('FOO'),
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -28,6 +32,7 @@ it('can acquire a non-fungible asset', function () {
     // Then
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $acquireNonFungibleAsset->asset,
         date: $acquireNonFungibleAsset->date,
         costBasis: $acquireNonFungibleAsset->costBasis,
     );
@@ -41,6 +46,7 @@ it('cannot acquire the same non-fungible asset more than once', function () {
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -48,14 +54,14 @@ it('cannot acquire the same non-fungible asset more than once', function () {
     // When
 
     $acquireSameNonFungibleAsset = new AcquireNonFungibleAsset(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
 
     // Then
 
-    $alreadyAcquired = NonFungibleAssetException::alreadyAcquired($this->aggregateRootId);
+    $alreadyAcquired = NonFungibleAssetException::alreadyAcquired($this->asset);
 
     /** @var AggregateRootTestCase $this */
     $this->given($nonFungibleAssetAcquired)
@@ -67,6 +73,7 @@ it('can increase the cost basis of a non-fungible asset', function () {
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -74,7 +81,7 @@ it('can increase the cost basis of a non-fungible asset', function () {
     // When
 
     $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: FiatAmount::GBP('50'),
     );
@@ -82,6 +89,7 @@ it('can increase the cost basis of a non-fungible asset', function () {
     // Then
 
     $nonFungibleAssetCostBasisIncreased = new NonFungibleAssetCostBasisIncreased(
+        asset: $increaseNonFungibleAssetCostBasis->asset,
         date: $increaseNonFungibleAssetCostBasis->date,
         costBasisIncrease: $increaseNonFungibleAssetCostBasis->costBasisIncrease,
     );
@@ -96,14 +104,14 @@ it('cannot increase the cost basis of a non-fungible asset that has not been acq
     // When
 
     $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
-        asset: new Asset('FOO'),
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: FiatAmount::GBP('100'),
     );
 
     // Then
 
-    $cannotIncreaseCostBasis = NonFungibleAssetException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId);
+    $cannotIncreaseCostBasis = NonFungibleAssetException::cannotIncreaseCostBasisBeforeAcquisition($this->asset);
 
     /** @var AggregateRootTestCase $this */
     $this->when($increaseNonFungibleAssetCostBasis)
@@ -114,6 +122,7 @@ it('cannot increase the cost basis of a non-fungible asset because the transacti
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -121,7 +130,7 @@ it('cannot increase the cost basis of a non-fungible asset because the transacti
     // When
 
     $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-20'),
         costBasisIncrease: FiatAmount::GBP('100'),
     );
@@ -129,9 +138,8 @@ it('cannot increase the cost basis of a non-fungible asset because the transacti
     // Then
 
     $cannotIncreaseCostBasis = NonFungibleAssetException::olderThanPreviousTransaction(
-        $this->aggregateRootId,
-        $increaseNonFungibleAssetCostBasis,
-        $nonFungibleAssetAcquired->date,
+        action: $increaseNonFungibleAssetCostBasis,
+        previousTransactionDate: $nonFungibleAssetAcquired->date,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -144,6 +152,7 @@ it('cannot increase the cost basis of a non-fungible asset because the currency 
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -151,15 +160,15 @@ it('cannot increase the cost basis of a non-fungible asset because the currency 
     // When
 
     $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     // Then
 
-    $cannotIncreaseCostBasis = NonFungibleAssetException::cannotIncreaseCostBasisFromDifferentCurrency(
-        nonFungibleAssetId: $this->aggregateRootId,
+    $cannotIncreaseCostBasis = NonFungibleAssetException::currencyMismatch(
+        action: $increaseNonFungibleAssetCostBasis,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
     );
@@ -174,6 +183,7 @@ it('can dispose of a non-fungible asset', function () {
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -181,7 +191,7 @@ it('can dispose of a non-fungible asset', function () {
     // When
 
     $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-21'),
         proceeds: FiatAmount::GBP('150'),
     );
@@ -189,6 +199,7 @@ it('can dispose of a non-fungible asset', function () {
     // Then
 
     $nonFungibleAssetDisposedOf = new NonFungibleAssetDisposedOf(
+        asset: $disposeOfNonFungibleAsset->asset,
         date: $disposeOfNonFungibleAsset->date,
         costBasis: $nonFungibleAssetAcquired->costBasis,
         proceeds: $disposeOfNonFungibleAsset->proceeds,
@@ -204,14 +215,14 @@ it('cannot dispose of a non-fungible asset that has not been acquired', function
     // When
 
     $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
-        asset: new Asset('FOO'),
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         proceeds: FiatAmount::GBP('100'),
     );
 
     // Then
 
-    $cannotDisposeOf = NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId);
+    $cannotDisposeOf = NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($this->asset);
 
     /** @var AggregateRootTestCase $this */
     $this->when($disposeOfNonFungibleAsset)
@@ -222,6 +233,7 @@ it('cannot dispose of a non-fungible asset because the transaction is older than
     // Given
 
     $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
     );
@@ -229,7 +241,7 @@ it('cannot dispose of a non-fungible asset because the transaction is older than
     // When
 
     $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
-        asset: new Asset('FOO'),
+        asset: $nonFungibleAssetAcquired->asset,
         date: LocalDate::parse('2015-10-20'),
         proceeds: FiatAmount::GBP('150'),
     );
@@ -237,9 +249,8 @@ it('cannot dispose of a non-fungible asset because the transaction is older than
     // Then
 
     $cannotDisposeOf = NonFungibleAssetException::olderThanPreviousTransaction(
-        $this->aggregateRootId,
-        $disposeOfNonFungibleAsset,
-        $nonFungibleAssetAcquired->date,
+        action: $disposeOfNonFungibleAsset,
+        previousTransactionDate: $nonFungibleAssetAcquired->date,
     );
 
     /** @var AggregateRootTestCase $this */

--- a/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
@@ -12,7 +12,7 @@ use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
 uses(NonFungibleAssetReactorTestCase::class);
 
 beforeEach(function () {
-    $this->asset = new Asset(symbol: 'foo', isNonFungible: true);
+    $this->asset = Asset::nonFungible('foo');
 });
 
 it('can handle a capital gain', function () {

--- a/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
@@ -4,14 +4,20 @@ use Brick\DateTime\LocalDate;
 use Domain\Aggregates\NonFungibleAsset\Events\NonFungibleAssetDisposedOf;
 use Domain\Aggregates\TaxYear\Actions\UpdateCapitalGain;
 use Domain\Tests\Aggregates\NonFungibleAsset\Reactors\NonFungibleAssetReactorTestCase;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
 
 uses(NonFungibleAssetReactorTestCase::class);
 
+beforeEach(function () {
+    $this->asset = new Asset(symbol: 'foo', isNonFungible: true);
+});
+
 it('can handle a capital gain', function () {
     $nonFungibleAssetDisposedOf = new NonFungibleAssetDisposedOf(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
         proceeds: FiatAmount::GBP('101'),
@@ -28,6 +34,7 @@ it('can handle a capital gain', function () {
 
 it('can handle a capital loss', function () {
     $nonFungibleAssetDisposedOf = new NonFungibleAssetDisposedOf(
+        asset: $this->asset,
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
         proceeds: FiatAmount::GBP('99'),

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
@@ -5,6 +5,7 @@ use Brick\DateTime\TimeZone;
 use Domain\Aggregates\SharePoolingAsset\Entities\Exceptions\SharePoolingAssetAcquisitionException;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 
@@ -21,6 +22,7 @@ it('cannot instantiate an acquisition because the allocated quantity is greater 
 
 it('can instantiate an acquisition', function () {
     $acquisition = new SharePoolingAssetAcquisition(
+        asset: new Asset('FOO'),
         date: LocalDate::now(TimeZone::utc()),
         quantity: Quantity::zero(),
         costBasis: FiatAmount::GBP('100'),

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalTest.php
@@ -8,6 +8,7 @@ use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\QuantityAllocation;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
 use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 
@@ -34,6 +35,7 @@ it('cannot instantiate a disposal because the allocated quantity is greater than
 
 it('can instantiate a disposal', function () {
     $disposal = new SharePoolingAssetDisposal(
+        asset: new Asset('FOO'),
         date: LocalDate::now(TimeZone::utc()),
         quantity: Quantity::zero(),
         costBasis: FiatAmount::GBP('100'),

--- a/domain/tests/Aggregates/SharePoolingAsset/Factories/Entities/SharePoolingAssetAcquisitionFactory.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Factories/Entities/SharePoolingAssetAcquisitionFactory.php
@@ -5,6 +5,7 @@ namespace Domain\Tests\Aggregates\SharePoolingAsset\Factories\Entities;
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 use Tests\Factories\PlainObjectFactory;
@@ -24,6 +25,7 @@ class SharePoolingAssetAcquisitionFactory extends PlainObjectFactory
     {
         return [
             'id' => SharePoolingAssetTransactionId::generate(),
+            'asset' => new Asset('FOO'),
             'date' => LocalDate::parse('2015-10-21'),
             'quantity' => new Quantity('100'),
             'costBasis' => FiatAmount::GBP('100'),

--- a/domain/tests/Aggregates/SharePoolingAsset/Factories/Entities/SharePoolingAssetDisposalFactory.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Factories/Entities/SharePoolingAssetDisposalFactory.php
@@ -7,6 +7,7 @@ use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\QuantityAllocation;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
 use Tests\Factories\PlainObjectFactory;
@@ -26,6 +27,7 @@ class SharePoolingAssetDisposalFactory extends PlainObjectFactory
     {
         return [
             'id' => SharePoolingAssetTransactionId::generate(),
+            'asset' => new Asset('FOO'),
             'date' => LocalDate::parse('2015-10-21'),
             'quantity' => new Quantity('100'),
             'costBasis' => FiatAmount::GBP('100'),
@@ -40,6 +42,7 @@ class SharePoolingAssetDisposalFactory extends PlainObjectFactory
     {
         return $this->state([
             'id' => $transaction->id,
+            'asset' => $transaction->asset,
             'date' => $transaction->date,
             'quantity' => $transaction->quantity,
             'costBasis' => $transaction->costBasis,

--- a/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
 use Domain\Aggregates\SharePoolingAsset\Events\SharePoolingAssetDisposalReverted;
 use Domain\Aggregates\SharePoolingAsset\Events\SharePoolingAssetDisposedOf;
@@ -16,12 +15,11 @@ uses(SharePoolingAssetReactorTestCase::class);
 
 it('can handle a capital gain update', function (string $costBasis, string $proceeds, string $capitalGain) {
     $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
-        new SharePoolingAssetDisposal(
-            date: LocalDate::parse('2015-10-21'),
-            quantity: new Quantity('100'),
-            costBasis: FiatAmount::GBP($costBasis),
-            proceeds: FiatAmount::GBP($proceeds),
-        ),
+        SharePoolingAssetDisposal::factory()->make([
+            'quantity' => new Quantity('100'),
+            'costBasis' => FiatAmount::GBP($costBasis),
+            'proceeds' => FiatAmount::GBP($proceeds),
+        ]),
     );
 
     /** @var MessageConsumerTestCase $this */
@@ -38,12 +36,11 @@ it('can handle a capital gain update', function (string $costBasis, string $proc
 
 it('can handle a capital gain update reversion', function (string $costBasis, string $proceeds, string $capitalGain) {
     $sharePoolingAssetDisposalReverted = new SharePoolingAssetDisposalReverted(
-        new SharePoolingAssetDisposal(
-            date: LocalDate::parse('2015-10-21'),
-            quantity: new Quantity('100'),
-            costBasis: FiatAmount::GBP($costBasis),
-            proceeds: FiatAmount::GBP($proceeds),
-        ),
+        SharePoolingAssetDisposal::factory()->make([
+            'quantity' => new Quantity('100'),
+            'costBasis' => FiatAmount::GBP($costBasis),
+            'proceeds' => FiatAmount::GBP($proceeds),
+        ]),
     );
 
     /** @var MessageConsumerTestCase $this */

--- a/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
@@ -39,13 +39,14 @@ it('can acquire a share pooling asset', function () {
 
     // Then
 
-    $sharePoolingAssetSet = new SharePoolingAssetSet($this->asset);
+    $sharePoolingAssetSet = new SharePoolingAssetSet($acquireSharePoolingAsset->asset);
 
     $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireSharePoolingAsset->transactionId,
+            asset: $acquireSharePoolingAsset->asset,
             date: $acquireSharePoolingAsset->date,
             quantity: new Quantity('100'),
             costBasis: $acquireSharePoolingAsset->costBasis,
@@ -66,6 +67,7 @@ it('can acquire more of the same share pooling asset', function () {
 
     $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -76,7 +78,7 @@ it('can acquire more of the same share pooling asset', function () {
 
     $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: FiatAmount::GBP('300'),
@@ -87,6 +89,7 @@ it('can acquire more of the same share pooling asset', function () {
     $moreSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireMoreSharePoolingAsset->transactionId,
+            asset: $acquireMoreSharePoolingAsset->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('300'),
@@ -108,6 +111,7 @@ it('cannot acquire more of the same share pooling asset because the assets don\'
 
     $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -126,9 +130,7 @@ it('cannot acquire more of the same share pooling asset because the assets don\'
     // Then
 
     $cannotAcquireSharePoolingAsset = SharePoolingAssetException::assetMismatch(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $acquireMoreSharePoolingAsset,
-        current: $this->asset,
         incoming: $acquireMoreSharePoolingAsset->asset,
     );
 
@@ -147,6 +149,7 @@ it('cannot acquire more of the same share pooling asset because the currencies d
 
     $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -156,7 +159,7 @@ it('cannot acquire more of the same share pooling asset because the currencies d
     // When
 
     $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: new FiatAmount('300', FiatCurrency::EUR),
@@ -165,7 +168,6 @@ it('cannot acquire more of the same share pooling asset because the currencies d
     // Then
 
     $cannotAcquireSharePoolingAsset = SharePoolingAssetException::currencyMismatch(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $acquireMoreSharePoolingAsset,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
@@ -186,6 +188,7 @@ it('cannot acquire more of the same share pooling asset because the transaction 
 
     $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -195,7 +198,7 @@ it('cannot acquire more of the same share pooling asset because the transaction 
     // When
 
     $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-20'),
         quantity: new Quantity('100'),
         costBasis: FiatAmount::GBP('100'),
@@ -204,7 +207,6 @@ it('cannot acquire more of the same share pooling asset because the transaction 
     // Then
 
     $cannotAcquireSharePoolingAsset = SharePoolingAssetException::olderThanPreviousTransaction(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $acquireMoreSharePoolingAsset,
         previousTransactionDate: $someSharePoolingAssetAcquired->acquisition->date,
     );
@@ -224,6 +226,7 @@ it('can dispose of a share pooling asset', function () {
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('200'),
@@ -234,7 +237,7 @@ it('can dispose of a share pooling asset', function () {
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('50'),
         proceeds: FiatAmount::GBP('150'),
@@ -245,6 +248,7 @@ it('can dispose of a share pooling asset', function () {
     $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             id: $disposeOfSharePoolingAsset->transactionId,
+            asset: $disposeOfSharePoolingAsset->asset,
             date: $disposeOfSharePoolingAsset->date,
             quantity: $disposeOfSharePoolingAsset->quantity,
             costBasis: FiatAmount::GBP('100'),
@@ -267,6 +271,7 @@ it('cannot dispose of a share pooling asset because the assets don\'t match', fu
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -285,9 +290,7 @@ it('cannot dispose of a share pooling asset because the assets don\'t match', fu
     // Then
 
     $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::assetMismatch(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $disposeOfSharePoolingAsset,
-        current: $this->asset,
         incoming: $disposeOfSharePoolingAsset->asset,
     );
 
@@ -306,6 +309,7 @@ it('cannot dispose of a share pooling asset because the currencies don\'t match'
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -315,7 +319,7 @@ it('cannot dispose of a share pooling asset because the currencies don\'t match'
     // When
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('100'),
         proceeds: new FiatAmount('100', FiatCurrency::EUR),
@@ -324,7 +328,6 @@ it('cannot dispose of a share pooling asset because the currencies don\'t match'
     // Then
 
     $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::currencyMismatch(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $disposeOfSharePoolingAsset,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
@@ -345,6 +348,7 @@ it('cannot dispose of a share pooling asset because the transaction is older tha
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -354,7 +358,7 @@ it('cannot dispose of a share pooling asset because the transaction is older tha
     // When
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-20'),
         quantity: new Quantity('100'),
         proceeds: FiatAmount::GBP('100'),
@@ -363,7 +367,6 @@ it('cannot dispose of a share pooling asset because the transaction is older tha
     // Then
 
     $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::olderThanPreviousTransaction(
-        sharePoolingAssetId: $this->aggregateRootId,
         action: $disposeOfSharePoolingAsset,
         previousTransactionDate: $sharePoolingAssetAcquired->acquisition->date,
     );
@@ -383,6 +386,7 @@ it('cannot dispose of a share pooling asset because the quantity is too high', f
 
     $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -392,7 +396,7 @@ it('cannot dispose of a share pooling asset because the quantity is too high', f
     // When
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('101'),
         proceeds: FiatAmount::GBP('100'),
@@ -401,7 +405,7 @@ it('cannot dispose of a share pooling asset because the quantity is too high', f
     // Then
 
     $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::insufficientQuantity(
-        sharePoolingAssetId: $this->aggregateRootId,
+        asset: $disposeOfSharePoolingAsset->asset,
         disposalQuantity: $disposeOfSharePoolingAsset->quantity,
         availableQuantity: new Quantity('100'),
     );
@@ -421,6 +425,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -429,6 +434,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-23'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('65'),
@@ -439,7 +445,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('20'),
         proceeds: FiatAmount::GBP('40'),
@@ -450,6 +456,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
     $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()->make([
             'id' => $disposeOfSharePoolingAsset->transactionId,
+            'asset' => $disposeOfSharePoolingAsset->asset,
             'date' => $disposeOfSharePoolingAsset->date,
             'quantity' => $disposeOfSharePoolingAsset->quantity,
             'costBasis' => FiatAmount::GBP('22'),
@@ -477,6 +484,7 @@ it('can dispose of a share pooling asset on the same day they were acquired', fu
 
     $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -485,6 +493,7 @@ it('can dispose of a share pooling asset on the same day they were acquired', fu
 
     $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('150'),
@@ -495,7 +504,7 @@ it('can dispose of a share pooling asset on the same day they were acquired', fu
 
     $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-26'),
         quantity: new Quantity('150'),
         proceeds: FiatAmount::GBP('300'),
@@ -508,6 +517,7 @@ it('can dispose of a share pooling asset on the same day they were acquired', fu
             ->withSameDayQuantity(new Quantity('100'), id: $moreSharePoolingAssetsAcquired->acquisition->id)
             ->make([
                 'id' => $disposeOfSharePoolingAsset->transactionId,
+                'asset' => $disposeOfSharePoolingAsset->asset,
                 'date' => $disposeOfSharePoolingAsset->date,
                 'quantity' => $disposeOfSharePoolingAsset->quantity,
                 'costBasis' => FiatAmount::GBP('200'),
@@ -535,6 +545,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -543,6 +554,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-23'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('65'),
@@ -551,6 +563,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $someSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-25'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('22'),
@@ -560,6 +573,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $evenMoreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('30'),
             costBasis: FiatAmount::GBP('36'),
@@ -570,7 +584,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
 
     $disposeOfMoreSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-26'),
         quantity: new Quantity('60'),
         proceeds: FiatAmount::GBP('70'),
@@ -583,6 +597,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
             ->withSameDayQuantity(new Quantity('30'), id: $evenMoreSharePoolingAssetsAcquired->acquisition->id)
             ->make([
                 'id' => $disposeOfMoreSharePoolingAsset->transactionId,
+                'asset' => $disposeOfMoreSharePoolingAsset->asset,
                 'date' => $disposeOfMoreSharePoolingAsset->date,
                 'quantity' => $disposeOfMoreSharePoolingAsset->quantity,
                 'costBasis' => FiatAmount::GBP('69'),
@@ -612,6 +627,7 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
 
     $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -620,6 +636,7 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
 
     $someSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
@@ -631,7 +648,7 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
 
     $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('25'),
         costBasis: FiatAmount::GBP('20'),
@@ -646,6 +663,7 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
     $moreSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireMoreSharePoolingAsset->transactionId,
+            asset: $acquireMoreSharePoolingAsset->asset,
             date: $acquireMoreSharePoolingAsset->date,
             quantity: $acquireMoreSharePoolingAsset->quantity,
             costBasis: $acquireMoreSharePoolingAsset->costBasis,
@@ -683,6 +701,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
 
     $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -691,6 +710,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
 
     $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
@@ -702,6 +722,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
+                'asset' => $sharePoolingAssetSet->asset,
                 'date' => LocalDate::parse('2015-10-22'),
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('75'),
@@ -710,6 +731,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
 
     $sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-25'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('25'),
@@ -719,6 +741,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
 
     $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
@@ -741,7 +764,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
 
     $acquireSharePoolingAsset4 = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('20'),
         costBasis: FiatAmount::GBP('40'),
@@ -760,6 +783,7 @@ it('can acquire a share pooling asset several times within 30 days of their disp
     $sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireSharePoolingAsset4->transactionId,
+            asset: $acquireSharePoolingAsset4->asset,
             date: $acquireSharePoolingAsset4->date,
             quantity: $acquireSharePoolingAsset4->quantity,
             costBasis: $acquireSharePoolingAsset4->costBasis,
@@ -812,6 +836,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
 
     $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -820,6 +845,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
 
     $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
@@ -831,6 +857,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
+                'asset' => $sharePoolingAssetSet->asset,
                 'date' => LocalDate::parse('2015-10-22'),
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('75'),
@@ -848,6 +875,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
 
     $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
@@ -868,6 +896,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
 
     $sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-29'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('40'),
@@ -905,7 +934,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
 
     $disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('10'),
         proceeds: FiatAmount::GBP('30'),
@@ -929,6 +958,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
             ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired4->acquisition->id)
             ->make([
                 'id' => $disposeOfSharePoolingAsset3->transactionId,
+                'asset' => $disposeOfSharePoolingAsset3->asset,
                 'date' => $disposeOfSharePoolingAsset3->date,
                 'quantity' => $disposeOfSharePoolingAsset3->quantity,
                 'costBasis' => FiatAmount::GBP('20'),
@@ -967,6 +997,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
 
     $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -975,6 +1006,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
 
     $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
@@ -988,6 +1020,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
 
     $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
@@ -1000,6 +1033,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
             ->revert($sharePoolingAssetDisposedOf->disposal)
             ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
+                'asset' => $sharePoolingAssetSet->asset,
                 'date' => LocalDate::parse('2015-10-22'),
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('55'),
@@ -1010,7 +1044,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
 
     $acquireSharePoolingAsset3 = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('10'),
         costBasis: FiatAmount::GBP('14'),
@@ -1025,6 +1059,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
     $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireSharePoolingAsset3->transactionId,
+            asset: $acquireSharePoolingAsset3->asset,
             date: $acquireSharePoolingAsset3->date,
             quantity: $acquireSharePoolingAsset3->quantity,
             costBasis: $acquireSharePoolingAsset3->costBasis,
@@ -1063,6 +1098,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
 
     $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
@@ -1071,6 +1107,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
 
     $sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
@@ -1084,6 +1121,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
 
     $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
@@ -1104,6 +1142,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
 
     $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
+            asset: $sharePoolingAssetSet->asset,
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('60'),
             costBasis: FiatAmount::GBP('90'),
@@ -1122,7 +1161,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
 
     $disposeOfSharePoolingAsset2 = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
-        asset: $this->asset,
+        asset: $sharePoolingAssetSet->asset,
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('40'),
         proceeds: FiatAmount::GBP('50'),
@@ -1135,6 +1174,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
             ->withSameDayQuantity(new Quantity('30'), id: $sharePoolingAssetAcquired3->acquisition->id)
             ->make([
                 'id' => $disposeOfSharePoolingAsset2->transactionId,
+                'asset' => $disposeOfSharePoolingAsset2->asset,
                 'date' => $disposeOfSharePoolingAsset2->date,
                 'quantity' => $disposeOfSharePoolingAsset2->quantity,
                 'costBasis' => FiatAmount::GBP('53.125'),

--- a/domain/tests/Factories/ValueObjects/Transactions/AcquisitionFactory.php
+++ b/domain/tests/Factories/ValueObjects/Transactions/AcquisitionFactory.php
@@ -37,7 +37,7 @@ class AcquisitionFactory extends TransactionFactory
     public function nonFungibleAsset(): static
     {
         return $this->state([
-            'asset' => new Asset(symbol: md5(time()), isNonFungible: true),
+            'asset' => Asset::nonFungible(md5(time())),
             'quantity' => new Quantity('1'),
         ]);
     }

--- a/domain/tests/Factories/ValueObjects/Transactions/DisposalFactory.php
+++ b/domain/tests/Factories/ValueObjects/Transactions/DisposalFactory.php
@@ -29,7 +29,7 @@ class DisposalFactory extends TransactionFactory
     public function nonFungibleAsset(): static
     {
         return $this->state([
-            'asset' => new Asset(symbol: md5(time()), isNonFungible: true),
+            'asset' => Asset::nonFungible(md5(time())),
             'quantity' => new Quantity('1'),
         ]);
     }

--- a/domain/tests/Factories/ValueObjects/Transactions/SwapFactory.php
+++ b/domain/tests/Factories/ValueObjects/Transactions/SwapFactory.php
@@ -32,7 +32,7 @@ class SwapFactory extends TransactionFactory
     public function toNonFungibleAsset(): static
     {
         return $this->state([
-            'acquiredAsset' => new Asset(symbol: md5(time()), isNonFungible: true),
+            'acquiredAsset' => Asset::nonFungible(md5(time())),
             'acquiredQuantity' => new Quantity('1'),
         ]);
     }
@@ -40,7 +40,7 @@ class SwapFactory extends TransactionFactory
     public function fromNonFungibleAsset(): static
     {
         return $this->state([
-            'disposedOfAsset' => new Asset(symbol: md5(time()), isNonFungible: true),
+            'disposedOfAsset' => Asset::nonFungible(md5(time())),
             'disposedOfQuantity' => new Quantity('1'),
         ]);
     }

--- a/domain/tests/Factories/ValueObjects/Transactions/TransferFactory.php
+++ b/domain/tests/Factories/ValueObjects/Transactions/TransferFactory.php
@@ -27,7 +27,7 @@ class TransferFactory extends TransactionFactory
     public function nonFungibleAsset(): static
     {
         return $this->state([
-            'asset' => new Asset(symbol: md5(time()), isNonFungible: true),
+            'asset' => Asset::nonFungible(md5(time())),
             'quantity' => new Quantity('1'),
         ]);
     }

--- a/domain/tests/ValueObjects/AssetTest.php
+++ b/domain/tests/ValueObjects/AssetTest.php
@@ -18,6 +18,13 @@ it('can instantiate an asset', function (string $symbol, bool $isNonFungible, st
     'scenario 4' => [' foo ', true, 'foo'],
 ]);
 
+it('can instantiate a non-fungible asset', function () {
+    $asset = Asset::nonFungible('foo');
+
+    expect($asset->symbol)->toBe('foo');
+    expect($asset->isNonFungible)->toBeTrue();
+});
+
 it('can tell whether two assets are the same', function (string $symbol1, bool $isNonFungible1, string $symbol2, bool $isNonFungible2, bool $result) {
     expect((new Asset($symbol1, $isNonFungible1))->is(new Asset($symbol2, $isNonFungible2)))->toBe($result);
 })->with([


### PR DESCRIPTION
## Summary

This PR makes sure the asset is present in all share-pooling and non-fungible assets events.

## Explanation

My initial assumption was that once the asset was set on the aggregate, it wasn't necessary to keep sending it with each event.

I realised that having it in every single event would most likely be useful for future projections built on top of these events, however.

I've also cleaned up the licence, Composer dependencies and CI workflow.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
