### PR TITLE
Use object mappers for event hydration

### DIFF
--- a/app/Aggregates/NonFungibleAsset/NonFungibleAssetServiceProvider.php
+++ b/app/Aggregates/NonFungibleAsset/NonFungibleAssetServiceProvider.php
@@ -15,7 +15,7 @@ use EventSauce\EventSourcing\ExplicitlyMappedClassNameInflector;
 use EventSauce\EventSourcing\MessageDecoratorChain;
 use EventSauce\EventSourcing\MessageDispatcherChain;
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
-use EventSauce\EventSourcing\Serialization\PayloadSerializerSupportingObjectMapperAndSerializablePayload;
+use EventSauce\EventSourcing\Serialization\ObjectMapperPayloadSerializer;
 use EventSauce\EventSourcing\SynchronousMessageDispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
@@ -33,10 +33,7 @@ class NonFungibleAssetServiceProvider extends ServiceProvider
             // @phpstan-ignore-next-line
             connection: $app->make(DatabaseManager::class)->connection(),
             tableName: 'non_fungible_asset_events',
-            serializer: new ConstructingMessageSerializer(
-                $classNameInflector,
-                new PayloadSerializerSupportingObjectMapperAndSerializablePayload(),
-            ),
+            serializer: new ConstructingMessageSerializer($classNameInflector, new ObjectMapperPayloadSerializer()),
             uuidEncoder: new UuidEncoder(),
         ));
 

--- a/app/Aggregates/SharePoolingAsset/SharePoolingAssetServiceProvider.php
+++ b/app/Aggregates/SharePoolingAsset/SharePoolingAssetServiceProvider.php
@@ -15,7 +15,7 @@ use EventSauce\EventSourcing\ExplicitlyMappedClassNameInflector;
 use EventSauce\EventSourcing\MessageDecoratorChain;
 use EventSauce\EventSourcing\MessageDispatcherChain;
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
-use EventSauce\EventSourcing\Serialization\PayloadSerializerSupportingObjectMapperAndSerializablePayload;
+use EventSauce\EventSourcing\Serialization\ObjectMapperPayloadSerializer;
 use EventSauce\EventSourcing\SynchronousMessageDispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
@@ -33,10 +33,7 @@ class SharePoolingAssetServiceProvider extends ServiceProvider
             // @phpstan-ignore-next-line
             connection: $app->make(DatabaseManager::class)->connection(),
             tableName: 'share_pooling_asset_events',
-            serializer: new ConstructingMessageSerializer(
-                $classNameInflector,
-                new PayloadSerializerSupportingObjectMapperAndSerializablePayload(),
-            ),
+            serializer: new ConstructingMessageSerializer($classNameInflector, new ObjectMapperPayloadSerializer()),
             uuidEncoder: new UuidEncoder(),
         ));
 

--- a/app/Aggregates/TaxYear/TaxYearServiceProvider.php
+++ b/app/Aggregates/TaxYear/TaxYearServiceProvider.php
@@ -17,7 +17,7 @@ use EventSauce\EventSourcing\ExplicitlyMappedClassNameInflector;
 use EventSauce\EventSourcing\MessageDecoratorChain;
 use EventSauce\EventSourcing\MessageDispatcherChain;
 use EventSauce\EventSourcing\Serialization\ConstructingMessageSerializer;
-use EventSauce\EventSourcing\Serialization\PayloadSerializerSupportingObjectMapperAndSerializablePayload;
+use EventSauce\EventSourcing\Serialization\ObjectMapperPayloadSerializer;
 use EventSauce\EventSourcing\SynchronousMessageDispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
@@ -40,10 +40,7 @@ class TaxYearServiceProvider extends ServiceProvider
             // @phpstan-ignore-next-line
             connection: $app->make(DatabaseManager::class)->connection(),
             tableName: 'tax_year_events',
-            serializer: new ConstructingMessageSerializer(
-                $classNameInflector,
-                new PayloadSerializerSupportingObjectMapperAndSerializablePayload(),
-            ),
+            serializer: new ConstructingMessageSerializer($classNameInflector, new ObjectMapperPayloadSerializer()),
             uuidEncoder: new UuidEncoder(),
         ));
 

--- a/app/Services/ObjectHydrators/CapitalGainHydrator.php
+++ b/app/Services/ObjectHydrators/CapitalGainHydrator.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ObjectHydrators;
+
+use Attribute;
+use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use EventSauce\ObjectHydrator\PropertySerializer;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final class CapitalGainHydrator implements PropertyCaster, PropertySerializer
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert(is_array($value));
+
+        return new CapitalGain(
+            costBasis: new FiatAmount($value['cost_basis']['quantity'], FiatCurrency::from($value['cost_basis']['currency'])),
+            proceeds: new FiatAmount($value['proceeds']['quantity'], FiatCurrency::from($value['proceeds']['currency'])),
+        );
+    }
+
+    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert($value instanceof CapitalGain);
+
+        return [
+            'cost_basis' => ['quantity' => (string) $value->costBasis->quantity, 'currency' => $value->costBasis->currency->value],
+            'proceeds' => ['quantity' => (string) $value->proceeds->quantity, 'currency' => $value->proceeds->currency->value],
+            'difference' => ['quantity' => (string) $value->difference->quantity, 'currency' => $value->difference->currency->value],
+        ];
+    }
+}

--- a/app/Services/ObjectHydrators/FiatAmountHydrator.php
+++ b/app/Services/ObjectHydrators/FiatAmountHydrator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ObjectHydrators;
+
+use Attribute;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use EventSauce\ObjectHydrator\PropertySerializer;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final class FiatAmountHydrator implements PropertyCaster, PropertySerializer
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert(is_array($value));
+
+        return new FiatAmount($value['quantity'], FiatCurrency::from($value['currency']));
+    }
+
+    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert($value instanceof FiatAmount);
+
+        return ['quantity' => (string) $value->quantity, 'currency' => $value->currency->value];
+    }
+}

--- a/app/Services/ObjectHydrators/LocalDateHydrator.php
+++ b/app/Services/ObjectHydrators/LocalDateHydrator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ObjectHydrators;
+
+use Attribute;
+use Brick\DateTime\LocalDate;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use EventSauce\ObjectHydrator\PropertySerializer;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final class LocalDateHydrator implements PropertyCaster, PropertySerializer
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert(is_string($value));
+
+        return LocalDate::parse($value);
+    }
+
+    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert($value instanceof LocalDate);
+
+        return (string) $value;
+    }
+}

--- a/app/Services/ObjectHydrators/SharePoolingAssetAcquisitionHydrator.php
+++ b/app/Services/ObjectHydrators/SharePoolingAssetAcquisitionHydrator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ObjectHydrators;
+
+use Attribute;
+use Brick\DateTime\LocalDate;
+use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
+use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Quantity;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use EventSauce\ObjectHydrator\PropertySerializer;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final class SharePoolingAssetAcquisitionHydrator implements PropertyCaster, PropertySerializer
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert(is_array($value));
+
+        return new SharePoolingAssetAcquisition(
+            id: ! empty($value['id']) ? SharePoolingAssetTransactionId::fromString($value['id']) : null,
+            date: LocalDate::parse($value['date']),
+            quantity: new Quantity($value['quantity']),
+            costBasis: new FiatAmount($value['cost_basis']['quantity'], FiatCurrency::from($value['cost_basis']['currency'])),
+            sameDayQuantity: new Quantity($value['same_day_quantity']),
+            thirtyDayQuantity: new Quantity($value['thirty_day_quantity']),
+        );
+    }
+
+    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert($value instanceof SharePoolingAssetAcquisition);
+
+        return [
+            'id' => (string) $value->id ?: null,
+            'date' => (string) $value->date,
+            'quantity' => (string) $value->quantity,
+            'cost_basis' => ['quantity' => (string) $value->costBasis->quantity, 'currency' => $value->costBasis->currency->value],
+            'same_day_quantity' => (string) $value->sameDayQuantity(),
+            'thirty_day_quantity' => (string) $value->thirtyDayQuantity(),
+        ];
+    }
+}

--- a/app/Services/ObjectHydrators/SharePoolingAssetDisposalHydrator.php
+++ b/app/Services/ObjectHydrators/SharePoolingAssetDisposalHydrator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ObjectHydrators;
+
+use Attribute;
+use Brick\DateTime\LocalDate;
+use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
+use Domain\Aggregates\SharePoolingAsset\ValueObjects\QuantityAllocation;
+use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use Domain\ValueObjects\Quantity;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use EventSauce\ObjectHydrator\PropertySerializer;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final class SharePoolingAssetDisposalHydrator implements PropertyCaster, PropertySerializer
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert(is_array($value));
+
+        return new SharePoolingAssetDisposal(
+            id: ! empty($value['id']) ? SharePoolingAssetTransactionId::fromString($value['id']) : null,
+            date: LocalDate::parse($value['date']),
+            quantity: new Quantity($value['quantity']),
+            costBasis: new FiatAmount($value['cost_basis']['quantity'], FiatCurrency::from($value['cost_basis']['currency'])),
+            proceeds: new FiatAmount($value['proceeds']['quantity'], FiatCurrency::from($value['proceeds']['currency'])),
+            sameDayQuantityAllocation: new QuantityAllocation(
+                array_map(fn (string $quantity) => new Quantity($quantity), $value['same_day_quantity_allocation']),
+            ),
+            thirtyDayQuantityAllocation: new QuantityAllocation(
+                array_map(fn (string $quantity) => new Quantity($quantity), $value['thirty_day_quantity_allocation']),
+            ),
+            processed: (bool) $value['processed'],
+        );
+    }
+
+    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        assert($value instanceof SharePoolingAssetDisposal);
+
+        return [
+            'id' => (string) $value->id ?: null,
+            'date' => (string) $value->date,
+            'quantity' => (string) $value->quantity,
+            'cost_basis' => ['quantity' => (string) $value->costBasis->quantity, 'currency' => $value->costBasis->currency->value],
+            'proceeds' => ['quantity' => (string) $value->proceeds->quantity, 'currency' => $value->proceeds->currency->value],
+            'same_day_quantity_allocation' => $this->serializeQuantityAllocation($value->sameDayQuantityAllocation),
+            'thirty_day_quantity_allocation' => $this->serializeQuantityAllocation($value->thirtyDayQuantityAllocation),
+            'processed' => $value->processed,
+        ];
+    }
+
+    /** @return array<string,string> */
+    private function serializeQuantityAllocation(QuantityAllocation $quantityAllocation): array
+    {
+        $reflectionClass = new ReflectionClass($quantityAllocation);
+
+        return array_map(
+            fn (Quantity $quantity) => (string) $quantity, // @phpstan-ignore-line
+            $reflectionClass->getProperty('allocation')->getValue($quantityAllocation), // @phpstan-ignore-line
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "brick/date-time": "^0.4.1",
         "eventsauce/eventsauce": "^3.2.2",
         "eventsauce/message-repository-for-illuminate": "^0.4.2",
+        "eventsauce/object-hydrator": "^1.0",
         "illuminate/database": "^10.3.3",
         "laravel-zero/framework": "^10.0",
         "nunomaduro/termwind": "^1.15.1",

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetAcquired.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetAcquired.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
+use App\Services\ObjectHydrators\FiatAmountHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class NonFungibleAssetAcquired implements SerializablePayload
+final readonly class NonFungibleAssetAcquired
 {
     public function __construct(
+        #[LocalDateHydrator]
         public LocalDate $date,
+        #[FiatAmountHydrator]
         public FiatAmount $costBasis,
     ) {
-    }
-
-    /** @return array{date:string,cost_basis:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'cost_basis' => $this->costBasis->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,cost_basis:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            FiatAmount::fromPayload($payload['cost_basis']),
-        );
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
+use App\Services\ObjectHydrators\FiatAmountHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class NonFungibleAssetCostBasisIncreased implements SerializablePayload
+final readonly class NonFungibleAssetCostBasisIncreased
 {
     public function __construct(
+        #[LocalDateHydrator]
         public LocalDate $date,
+        #[FiatAmountHydrator]
         public FiatAmount $costBasisIncrease,
     ) {
-    }
-
-    /** @return array{date:string,cost_basis_increase:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'cost_basis_increase' => $this->costBasisIncrease->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,cost_basis_increase:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            FiatAmount::fromPayload($payload['cost_basis_increase']),
-        );
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetDisposedOf.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetDisposedOf.php
@@ -4,36 +4,20 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\NonFungibleAsset\Events;
 
+use App\Services\ObjectHydrators\FiatAmountHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class NonFungibleAssetDisposedOf implements SerializablePayload
+final readonly class NonFungibleAssetDisposedOf
 {
     public function __construct(
+        #[LocalDateHydrator]
         public LocalDate $date,
+        #[FiatAmountHydrator]
         public FiatAmount $costBasis,
+        #[FiatAmountHydrator]
         public FiatAmount $proceeds,
     ) {
-    }
-
-    /** @return array{date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'cost_basis' => $this->costBasis->toPayload(),
-            'proceeds' => $this->proceeds->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            FiatAmount::fromPayload($payload['cost_basis']),
-            FiatAmount::fromPayload($payload['proceeds']),
-        );
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisition.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisition.php
@@ -10,9 +10,8 @@ use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactio
 use Domain\Tests\Aggregates\SharePoolingAsset\Factories\Entities\SharePoolingAssetAcquisitionFactory;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction implements SerializablePayload
+final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction
 {
     private Quantity $sameDayQuantity;
 
@@ -107,32 +106,6 @@ final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction im
         $this->thirtyDayQuantity = $this->thirtyDayQuantity->minus($quantity);
 
         return $this;
-    }
-
-    /** @return array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string} */
-    public function toPayload(): array
-    {
-        return [
-            'id' => (string) $this->id,
-            'date' => (string) $this->date,
-            'quantity' => (string) $this->quantity,
-            'cost_basis' => $this->costBasis->toPayload(),
-            'same_day_quantity' => (string) $this->sameDayQuantity,
-            'thirty_day_quantity' => (string) $this->thirtyDayQuantity,
-        ];
-    }
-
-    /** @param array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            id: SharePoolingAssetTransactionId::fromString($payload['id']),
-            date: LocalDate::parse($payload['date']),
-            quantity: new Quantity($payload['quantity']),
-            costBasis: FiatAmount::fromPayload($payload['cost_basis']),
-            sameDayQuantity: new Quantity($payload['same_day_quantity']),
-            thirtyDayQuantity: new Quantity($payload['thirty_day_quantity']),
-        );
     }
 
     public function __toString(): string

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposal.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposal.php
@@ -11,9 +11,8 @@ use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactio
 use Domain\Tests\Aggregates\SharePoolingAsset\Factories\Entities\SharePoolingAssetDisposalFactory;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class SharePoolingAssetDisposal extends SharePoolingAssetTransaction implements SerializablePayload
+final class SharePoolingAssetDisposal extends SharePoolingAssetTransaction
 {
     public readonly QuantityAllocation $sameDayQuantityAllocation;
 
@@ -80,36 +79,6 @@ final class SharePoolingAssetDisposal extends SharePoolingAssetTransaction imple
     public function thirtyDayQuantityAllocatedTo(SharePoolingAssetAcquisition $acquisition): Quantity
     {
         return $this->thirtyDayQuantityAllocation->quantityAllocatedTo($acquisition);
-    }
-
-    /** @return array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool} */
-    public function toPayload(): array
-    {
-        return [
-            'id' => (string) $this->id,
-            'date' => (string) $this->date,
-            'quantity' => (string) $this->quantity,
-            'cost_basis' => $this->costBasis->toPayload(),
-            'proceeds' => $this->proceeds->toPayload(),
-            'same_day_quantity_allocation' => $this->sameDayQuantityAllocation->toPayload(),
-            'thirty_day_quantity_allocation' => $this->thirtyDayQuantityAllocation->toPayload(),
-            'processed' => $this->processed,
-        ];
-    }
-
-    /** @param array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            id: SharePoolingAssetTransactionId::fromString($payload['id']),
-            date: LocalDate::parse($payload['date']),
-            quantity: new Quantity($payload['quantity']),
-            costBasis: FiatAmount::fromPayload($payload['cost_basis']),
-            proceeds: FiatAmount::fromPayload($payload['proceeds']),
-            sameDayQuantityAllocation: QuantityAllocation::fromPayload($payload['same_day_quantity_allocation']),
-            thirtyDayQuantityAllocation: QuantityAllocation::fromPayload($payload['thirty_day_quantity_allocation']),
-            processed: (bool) $payload['processed'],
-        );
     }
 
     public function __toString(): string

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetAcquired.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetAcquired.php
@@ -4,25 +4,14 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\SharePoolingAsset\Events;
 
+use App\Services\ObjectHydrators\SharePoolingAssetAcquisitionHydrator;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class SharePoolingAssetAcquired implements SerializablePayload
+final readonly class SharePoolingAssetAcquired
 {
     public function __construct(
+        #[SharePoolingAssetAcquisitionHydrator]
         public SharePoolingAssetAcquisition $acquisition,
     ) {
-    }
-
-    /** @return array{share_pooling_asset_acquisition:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} */
-    public function toPayload(): array
-    {
-        return ['share_pooling_asset_acquisition' => $this->acquisition->toPayload()];
-    }
-
-    /** @param array{share_pooling_asset_acquisition:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},same_day_quantity:string,thirty_day_quantity:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(SharePoolingAssetAcquisition::fromPayload($payload['share_pooling_asset_acquisition']));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposalReverted.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposalReverted.php
@@ -4,25 +4,14 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\SharePoolingAsset\Events;
 
+use App\Services\ObjectHydrators\SharePoolingAssetDisposalHydrator;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class SharePoolingAssetDisposalReverted implements SerializablePayload
+final readonly class SharePoolingAssetDisposalReverted
 {
     public function __construct(
+        #[SharePoolingAssetDisposalHydrator]
         public SharePoolingAssetDisposal $disposal,
     ) {
-    }
-
-    /** @return array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
-    public function toPayload(): array
-    {
-        return ['share_pooling_asset_disposal' => $this->disposal->toPayload()];
-    }
-
-    /** @param array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(SharePoolingAssetDisposal::fromPayload($payload['share_pooling_asset_disposal']));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposedOf.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetDisposedOf.php
@@ -4,25 +4,14 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\SharePoolingAsset\Events;
 
+use App\Services\ObjectHydrators\SharePoolingAssetDisposalHydrator;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class SharePoolingAssetDisposedOf implements SerializablePayload
+final readonly class SharePoolingAssetDisposedOf
 {
     public function __construct(
+        #[SharePoolingAssetDisposalHydrator]
         public SharePoolingAssetDisposal $disposal,
     ) {
-    }
-
-    /** @return array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} */
-    public function toPayload(): array
-    {
-        return ['share_pooling_asset_disposal' => $this->disposal->toPayload()];
-    }
-
-    /** @param array{share_pooling_asset_disposal:array{id:string,date:string,quantity:string,cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},same_day_quantity_allocation:array{allocation:array<string,string>},thirty_day_quantity_allocation:array{allocation:array<string,string>},processed:bool}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(SharePoolingAssetDisposal::fromPayload($payload['share_pooling_asset_disposal']));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetFiatCurrencySet.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Events/SharePoolingAssetFiatCurrencySet.php
@@ -5,24 +5,11 @@ declare(strict_types=1);
 namespace Domain\Aggregates\SharePoolingAsset\Events;
 
 use Domain\Enums\FiatCurrency;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final readonly class SharePoolingAssetFiatCurrencySet implements SerializablePayload
+final readonly class SharePoolingAssetFiatCurrencySet
 {
     public function __construct(
         public FiatCurrency $fiatCurrency,
     ) {
-    }
-
-    /** @return array{fiat_currency:string} */
-    public function toPayload(): array
-    {
-        return ['fiat_currency' => $this->fiatCurrency->value];
-    }
-
-    /** @param array{fiat_currency:string} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(FiatCurrency::from($payload['fiat_currency']));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/ValueObjects/QuantityAllocation.php
+++ b/domain/src/Aggregates/SharePoolingAsset/ValueObjects/QuantityAllocation.php
@@ -6,9 +6,8 @@ namespace Domain\Aggregates\SharePoolingAsset\ValueObjects;
 
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\ValueObjects\Quantity;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class QuantityAllocation implements SerializablePayload
+final class QuantityAllocation
 {
     /** @param array<string,Quantity> $allocation */
     public function __construct(private array $allocation = [])
@@ -52,21 +51,5 @@ final class QuantityAllocation implements SerializablePayload
     public function transactionIds(): array
     {
         return array_map(fn (string $id) => SharePoolingAssetTransactionId::fromString($id), array_keys($this->allocation));
-    }
-
-    /** @return array{allocation:array<string,string>} */
-    public function toPayload(): array
-    {
-        return [
-            'allocation' => array_map(fn (Quantity $quantity) => (string) $quantity, $this->allocation),
-        ];
-    }
-
-    /** @param array{allocation:array<string,string>} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            allocation: array_map(fn (string $quantity) => new Quantity($quantity), $payload['allocation']),
-        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdateReverted.php
+++ b/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdateReverted.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Events;
 
+use App\Services\ObjectHydrators\CapitalGainHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class CapitalGainUpdateReverted implements SerializablePayload
+final class CapitalGainUpdateReverted
 {
     final public function __construct(
+        #[LocalDateHydrator]
         public readonly LocalDate $date,
+        #[CapitalGainHydrator]
         public readonly CapitalGain $capitalGain,
     ) {
-    }
-
-    /** @return array{date:string,capital_gain:array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},difference:array{quantity:string,currency:string}}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'capital_gain' => $this->capitalGain->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,capital_gain:array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},difference:array{quantity:string,currency:string}}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            CapitalGain::fromPayload($payload['capital_gain']),
-        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdated.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Events;
 
+use App\Services\ObjectHydrators\CapitalGainHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class CapitalGainUpdated implements SerializablePayload
+final class CapitalGainUpdated
 {
     final public function __construct(
+        #[LocalDateHydrator]
         public readonly LocalDate $date,
+        #[CapitalGainHydrator]
         public readonly CapitalGain $capitalGain,
     ) {
-    }
-
-    /** @return array{date:string,capital_gain:array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},difference:array{quantity:string,currency:string}}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'capital_gain' => $this->capitalGain->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,capital_gain:array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},difference:array{quantity:string,currency:string}}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            CapitalGain::fromPayload($payload['capital_gain']),
-        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/IncomeUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/IncomeUpdated.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Events;
 
+use App\Services\ObjectHydrators\FiatAmountHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class IncomeUpdated implements SerializablePayload
+final class IncomeUpdated
 {
     public function __construct(
+        #[LocalDateHydrator]
         public readonly LocalDate $date,
+        #[FiatAmountHydrator]
         public readonly FiatAmount $income,
     ) {
-    }
-
-    /** @return array{date:string,income:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'income' => $this->income->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,income:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            FiatAmount::fromPayload($payload['income']),
-        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/NonAttributableAllowableCostUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/NonAttributableAllowableCostUpdated.php
@@ -4,33 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Events;
 
+use App\Services\ObjectHydrators\FiatAmountHydrator;
+use App\Services\ObjectHydrators\LocalDateHydrator;
 use Brick\DateTime\LocalDate;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-final class NonAttributableAllowableCostUpdated implements SerializablePayload
+final class NonAttributableAllowableCostUpdated
 {
     public function __construct(
+        #[LocalDateHydrator]
         public readonly LocalDate $date,
+        #[FiatAmountHydrator]
         public readonly FiatAmount $nonAttributableAllowableCost,
     ) {
-    }
-
-    /** @return array{date:string,non_attributable_allowable_cost:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'date' => (string) $this->date,
-            'non_attributable_allowable_cost' => $this->nonAttributableAllowableCost->toPayload(),
-        ];
-    }
-
-    /** @param array{date:string,non_attributable_allowable_cost:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            LocalDate::parse($payload['date']),
-            FiatAmount::fromPayload($payload['non_attributable_allowable_cost']),
-        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
@@ -6,11 +6,10 @@ namespace Domain\Aggregates\TaxYear\ValueObjects;
 
 use Domain\Enums\FiatCurrency;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 use JsonSerializable;
 use Stringable;
 
-final readonly class CapitalGain implements JsonSerializable, SerializablePayload, Stringable
+final readonly class CapitalGain implements JsonSerializable, Stringable
 {
     public FiatAmount $difference;
 
@@ -56,25 +55,6 @@ final readonly class CapitalGain implements JsonSerializable, SerializablePayloa
             'proceeds' => (string) $this->proceeds->quantity,
             'difference' => (string) $this->difference->quantity,
         ];
-    }
-
-    /** @return array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string},difference:array{quantity:string,currency:string}} */
-    public function toPayload(): array
-    {
-        return [
-            'cost_basis' => $this->costBasis->toPayload(),
-            'proceeds' => $this->proceeds->toPayload(),
-            'difference' => $this->difference->toPayload(),
-        ];
-    }
-
-    /** @param array{cost_basis:array{quantity:string,currency:string},proceeds:array{quantity:string,currency:string}} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            costBasis: FiatAmount::fromPayload($payload['cost_basis']),
-            proceeds: FiatAmount::fromPayload($payload['proceeds']),
-        );
     }
 
     public function __toString(): string

--- a/domain/src/ValueObjects/Asset.php
+++ b/domain/src/ValueObjects/Asset.php
@@ -6,10 +6,9 @@ namespace Domain\ValueObjects;
 
 use Domain\Enums\FiatCurrency;
 use Domain\ValueObjects\Exceptions\AssetException;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 use Stringable;
 
-final readonly class Asset implements SerializablePayload, Stringable
+final readonly class Asset implements Stringable
 {
     public string|FiatCurrency $symbol;
 
@@ -38,24 +37,6 @@ final readonly class Asset implements SerializablePayload, Stringable
     public function isFiat(): bool
     {
         return $this->symbol instanceof FiatCurrency;
-    }
-
-    /** @return array{symbol:string,is_non_fungible:string} */
-    public function toPayload(): array
-    {
-        return [
-            'symbol' => $this->symbol instanceof FiatCurrency ? $this->symbol->value : $this->symbol,
-            'is_non_fungible' => (string) $this->isNonFungible,
-        ];
-    }
-
-    /** @param array{symbol:string,is_non_fungible:string} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            symbol: $payload['symbol'],
-            isNonFungible: (bool) $payload['is_non_fungible'],
-        );
     }
 
     public function __toString(): string

--- a/domain/src/ValueObjects/FiatAmount.php
+++ b/domain/src/ValueObjects/FiatAmount.php
@@ -7,10 +7,9 @@ namespace Domain\ValueObjects;
 use Domain\Enums\FiatCurrency;
 use Domain\ValueObjects\Exceptions\FiatAmountException;
 use Domain\ValueObjects\Exceptions\QuantityException;
-use EventSauce\EventSourcing\Serialization\SerializablePayload;
 use Stringable;
 
-final readonly class FiatAmount implements SerializablePayload, Stringable
+final readonly class FiatAmount implements Stringable
 {
     public Quantity $quantity;
 
@@ -128,24 +127,6 @@ final readonly class FiatAmount implements SerializablePayload, Stringable
         if (count($currencies) > 1) {
             throw FiatAmountException::fiatCurrenciesDoNotMatch(...$currencies);
         }
-    }
-
-    /** @return array{quantity:string,currency:string} */
-    public function toPayload(): array
-    {
-        return [
-            'quantity' => (string) $this->quantity,
-            'currency' => $this->currency->value,
-        ];
-    }
-
-    /** @param array{quantity:string,currency:string} $payload */
-    public static function fromPayload(array $payload): static
-    {
-        return new self(
-            quantity: new Quantity($payload['quantity']),
-            currency: FiatCurrency::from($payload['currency']),
-        );
     }
 
     public function __toString(): string

--- a/domain/tests/AggregateRootTestCase.php
+++ b/domain/tests/AggregateRootTestCase.php
@@ -2,8 +2,14 @@
 
 namespace Domain\Tests;
 
+use EventSauce\EventSourcing\Serialization\ObjectMapperPayloadSerializer;
+use EventSauce\EventSourcing\Serialization\PayloadSerializer;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase as BaseAggregateRootTestCase;
 
 abstract class AggregateRootTestCase extends BaseAggregateRootTestCase
 {
+    protected function payloadSerializer(): PayloadSerializer
+    {
+        return new ObjectMapperPayloadSerializer();
+    }
 }


### PR DESCRIPTION
## Summary

This PR introduces object mappers to replace the use of the `SerializablePayload` interface.

## Explanation

Doing so allows me to get rid of the `toPayload` and `fromPayload` methods in every event class.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
