### PR TITLE
Add computed values to events

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 /.github export-ignore
 .scrutinizer.yml export-ignore
 BACKERS.md export-ignore

--- a/app/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
+++ b/app/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
@@ -16,21 +16,21 @@ class TaxYearSummaryRepository implements TaxYearSummaryRepositoryInterface
     public function updateCapitalGain(TaxYearId $taxYearId, CapitalGain $capitalGain): void
     {
         $this->fetchTaxYearSummary($taxYearId, $capitalGain->currency())
-            ->updateCapitalGain($capitalGain)
+            ->fill(['capital_gain' => $capitalGain])
             ->save();
     }
 
     public function updateIncome(TaxYearId $taxYearId, FiatAmount $income): void
     {
         $this->fetchTaxYearSummary($taxYearId, $income->currency)
-            ->updateIncome($income)
+            ->fill(['income' => $income])
             ->save();
     }
 
     public function updateNonAttributableAllowableCost(TaxYearId $taxYearId, FiatAmount $nonAttributableAllowableCost): void
     {
         $this->fetchTaxYearSummary($taxYearId, $nonAttributableAllowableCost->currency)
-            ->updateNonAttributableAllowableCost($nonAttributableAllowableCost)
+            ->fill(['non_attributable_allowable_cost' => $nonAttributableAllowableCost])
             ->save();
     }
 

--- a/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Events/NonFungibleAssetCostBasisIncreased.php
@@ -12,6 +12,7 @@ final readonly class NonFungibleAssetCostBasisIncreased
     public function __construct(
         public LocalDate $date,
         public FiatAmount $costBasisIncrease,
+        public FiatAmount $newCostBasis,
     ) {
     }
 }

--- a/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/NonFungibleAsset.php
@@ -80,6 +80,7 @@ class NonFungibleAsset implements AggregateRoot
         $this->recordThat(new NonFungibleAssetCostBasisIncreased(
             date: $action->date,
             costBasisIncrease: $action->costBasisIncrease,
+            newCostBasis: $this->costBasis?->plus($action->costBasisIncrease) ?? $action->costBasisIncrease,
         ));
     }
 
@@ -87,7 +88,7 @@ class NonFungibleAsset implements AggregateRoot
     {
         assert(! is_null($this->costBasis));
 
-        $this->costBasis = $this->costBasis->plus($event->costBasisIncrease);
+        $this->costBasis = $event->newCostBasis;
         $this->previousTransactionDate = $event->date;
     }
 

--- a/domain/src/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactor.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactor.php
@@ -21,7 +21,7 @@ final class NonFungibleAssetReactor extends EventConsumer
     {
         $this->runner->run(new UpdateCapitalGain(
             date: $event->date,
-            capitalGain: new CapitalGain($event->costBasis, $event->proceeds),
+            capitalGainUpdate: new CapitalGain($event->costBasis, $event->proceeds),
         ));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactor.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactor.php
@@ -31,7 +31,7 @@ final class SharePoolingAssetReactor extends EventConsumer
     {
         $this->runner->run(new RevertCapitalGainUpdate(
             date: $event->disposal->date,
-            capitalGain: new CapitalGain($event->disposal->costBasis, $event->disposal->proceeds),
+            capitalGainUpdate: new CapitalGain($event->disposal->costBasis, $event->disposal->proceeds),
         ));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactor.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactor.php
@@ -23,7 +23,7 @@ final class SharePoolingAssetReactor extends EventConsumer
     {
         $this->runner->run(new UpdateCapitalGain(
             date: $event->disposal->date,
-            capitalGain: new CapitalGain($event->disposal->costBasis, $event->disposal->proceeds),
+            capitalGainUpdate: new CapitalGain($event->disposal->costBasis, $event->disposal->proceeds),
         ));
     }
 

--- a/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
+++ b/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
@@ -14,7 +14,7 @@ final class RevertCapitalGainUpdate implements Stringable
 {
     final public function __construct(
         public readonly LocalDate $date,
-        public readonly CapitalGain $capitalGain,
+        public readonly CapitalGain $capitalGainUpdate,
     ) {
     }
 
@@ -29,6 +29,6 @@ final class RevertCapitalGainUpdate implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, capital gain: (%s))', self::class, $this->date, $this->capitalGain);
+        return sprintf('%s (date: %s, capital gain: (%s))', self::class, $this->date, $this->capitalGainUpdate);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
@@ -29,6 +29,11 @@ final class UpdateCapitalGain implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, capital gain update: (%s))', self::class, $this->date, $this->capitalGainUpdate);
+        return sprintf(
+            '%s (date: %s, capital gain update change: (%s))',
+            self::class,
+            $this->date,
+            $this->capitalGainUpdate,
+        );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
@@ -14,7 +14,7 @@ final class UpdateCapitalGain implements Stringable
 {
     final public function __construct(
         public readonly LocalDate $date,
-        public readonly CapitalGain $capitalGain,
+        public readonly CapitalGain $capitalGainUpdate,
     ) {
     }
 
@@ -29,6 +29,6 @@ final class UpdateCapitalGain implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, capital gain: (%s))', self::class, $this->date, $this->capitalGain);
+        return sprintf('%s (date: %s, capital gain update: (%s))', self::class, $this->date, $this->capitalGainUpdate);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
@@ -29,6 +29,6 @@ final class UpdateIncome implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, income: %s)', self::class, $this->date, $this->incomeUpdate);
+        return sprintf('%s (date: %s, income change: %s)', self::class, $this->date, $this->incomeUpdate);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
@@ -14,7 +14,7 @@ final class UpdateIncome implements Stringable
 {
     public function __construct(
         public readonly LocalDate $date,
-        public readonly FiatAmount $income,
+        public readonly FiatAmount $incomeUpdate,
     ) {
     }
 
@@ -29,6 +29,6 @@ final class UpdateIncome implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s (date: %s, income: %s)', self::class, $this->date, $this->income);
+        return sprintf('%s (date: %s, income: %s)', self::class, $this->date, $this->incomeUpdate);
     }
 }

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
@@ -14,7 +14,7 @@ final class UpdateNonAttributableAllowableCost implements Stringable
 {
     public function __construct(
         public readonly LocalDate $date,
-        public readonly FiatAmount $nonAttributableAllowableCost,
+        public readonly FiatAmount $nonAttributableAllowableCostChange,
     ) {
     }
 
@@ -30,10 +30,10 @@ final class UpdateNonAttributableAllowableCost implements Stringable
     public function __toString(): string
     {
         return sprintf(
-            '%s (date: %s, non-attributable allowable cost: %s)',
+            '%s (date: %s, non-attributable allowable cost change: %s)',
             self::class,
             $this->date,
-            $this->nonAttributableAllowableCost,
+            $this->nonAttributableAllowableCostChange,
         );
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdateReverted.php
+++ b/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdateReverted.php
@@ -11,7 +11,8 @@ final class CapitalGainUpdateReverted
 {
     final public function __construct(
         public readonly LocalDate $date,
-        public readonly CapitalGain $capitalGain,
+        public readonly CapitalGain $capitalGainUpdate,
+        public readonly CapitalGain $newCapitalGain,
     ) {
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/CapitalGainUpdated.php
@@ -11,7 +11,8 @@ final class CapitalGainUpdated
 {
     final public function __construct(
         public readonly LocalDate $date,
-        public readonly CapitalGain $capitalGain,
+        public readonly CapitalGain $capitalGainUpdate,
+        public readonly CapitalGain $newCapitalGain,
     ) {
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/IncomeUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/IncomeUpdated.php
@@ -11,7 +11,8 @@ final class IncomeUpdated
 {
     public function __construct(
         public readonly LocalDate $date,
-        public readonly FiatAmount $income,
+        public readonly FiatAmount $incomeUpdate,
+        public readonly FiatAmount $newIncome,
     ) {
     }
 }

--- a/domain/src/Aggregates/TaxYear/Events/NonAttributableAllowableCostUpdated.php
+++ b/domain/src/Aggregates/TaxYear/Events/NonAttributableAllowableCostUpdated.php
@@ -11,7 +11,8 @@ final class NonAttributableAllowableCostUpdated
 {
     public function __construct(
         public readonly LocalDate $date,
-        public readonly FiatAmount $nonAttributableAllowableCost,
+        public readonly FiatAmount $nonAttributableAllowableCostChange,
+        public readonly FiatAmount $newNonAttributableAllowableCost,
     ) {
     }
 }

--- a/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
+++ b/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
@@ -9,7 +9,6 @@ use Domain\Enums\FiatCurrency;
 use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
 use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
 use Domain\Tests\Aggregates\TaxYear\Factories\Projections\TaxYearSummaryFactory;
-use Domain\ValueObjects\Exceptions\FiatAmountException;
 use Domain\ValueObjects\FiatAmount;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -46,33 +45,6 @@ final class TaxYearSummary extends Model
     protected static function newFactory(): TaxYearSummaryFactory
     {
         return TaxYearSummaryFactory::new();
-    }
-
-    /** @throws FiatAmountException */
-    public function updateCapitalGain(CapitalGain $capitalGain): self
-    {
-        $this->capital_gain = new CapitalGain(
-            costBasis: $this->capital_gain->costBasis->plus($capitalGain->costBasis),
-            proceeds: $this->capital_gain->proceeds->plus($capitalGain->proceeds),
-        );
-
-        return $this;
-    }
-
-    /** @throws FiatAmountException */
-    public function updateIncome(FiatAmount $amount): self
-    {
-        $this->income = $this->income->plus($amount);
-
-        return $this;
-    }
-
-    /** @throws FiatAmountException */
-    public function updateNonAttributableAllowableCost(FiatAmount $amount): self
-    {
-        $this->non_attributable_allowable_cost = $this->non_attributable_allowable_cost->plus($amount);
-
-        return $this;
     }
 
     protected function taxYearId(): Attribute

--- a/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -25,7 +25,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateCapitalGain(
             taxYearId: $this->getTaxYearId($message),
-            capitalGain: $event->capitalGainUpdate,
+            capitalGain: $event->newCapitalGain,
         );
     }
 
@@ -34,7 +34,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateCapitalGain(
             taxYearId: $this->getTaxYearId($message),
-            capitalGain: $event->capitalGainUpdate->opposite(),
+            capitalGain: $event->newCapitalGain,
         );
     }
 
@@ -43,7 +43,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateIncome(
             taxYearId: $this->getTaxYearId($message),
-            income: $event->incomeUpdate,
+            income: $event->newIncome,
         );
     }
 
@@ -54,7 +54,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     ): void {
         $this->taxYearSummaryRepository->updateNonAttributableAllowableCost(
             taxYearId: $this->getTaxYearId($message),
-            nonAttributableAllowableCost: $event->nonAttributableAllowableCostChange,
+            nonAttributableAllowableCost: $event->newNonAttributableAllowableCost,
         );
     }
 

--- a/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -54,7 +54,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     ): void {
         $this->taxYearSummaryRepository->updateNonAttributableAllowableCost(
             taxYearId: $this->getTaxYearId($message),
-            nonAttributableAllowableCost: $event->nonAttributableAllowableCost,
+            nonAttributableAllowableCost: $event->nonAttributableAllowableCostChange,
         );
     }
 

--- a/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -43,7 +43,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateIncome(
             taxYearId: $this->getTaxYearId($message),
-            income: $event->income,
+            income: $event->incomeUpdate,
         );
     }
 

--- a/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -34,7 +34,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateCapitalGain(
             taxYearId: $this->getTaxYearId($message),
-            capitalGain: $event->capitalGain->opposite(),
+            capitalGain: $event->capitalGainUpdate->opposite(),
         );
     }
 

--- a/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
+++ b/domain/src/Aggregates/TaxYear/Projectors/TaxYearSummaryProjector.php
@@ -25,7 +25,7 @@ final class TaxYearSummaryProjector extends EventConsumer
     {
         $this->taxYearSummaryRepository->updateCapitalGain(
             taxYearId: $this->getTaxYearId($message),
-            capitalGain: $event->capitalGain,
+            capitalGain: $event->capitalGainUpdate,
         );
     }
 

--- a/domain/src/Aggregates/TaxYear/TaxYear.php
+++ b/domain/src/Aggregates/TaxYear/TaxYear.php
@@ -105,19 +105,20 @@ class TaxYear implements AggregateRoot
     /** @throws TaxYearException */
     public function updateNonAttributableAllowableCost(UpdateNonAttributableAllowableCost $action): void
     {
-        $this->checkCurrency($action->nonAttributableAllowableCost->currency, $action);
+        $this->checkCurrency($action->nonAttributableAllowableCostChange->currency, $action);
 
         $this->recordThat(new NonAttributableAllowableCostUpdated(
             date: $action->date,
-            nonAttributableAllowableCost: $action->nonAttributableAllowableCost,
+            nonAttributableAllowableCostChange: $action->nonAttributableAllowableCostChange,
+            newNonAttributableAllowableCost: $this->nonAttributableAllowableCost?->plus($action->nonAttributableAllowableCostChange)
+                ?? $action->nonAttributableAllowableCostChange,
         ));
     }
 
     public function applyNonAttributableAllowableCostUpdated(NonAttributableAllowableCostUpdated $event): void
     {
-        $this->currency ??= $event->nonAttributableAllowableCost->currency;
-        $this->nonAttributableAllowableCost = $this->nonAttributableAllowableCost?->plus($event->nonAttributableAllowableCost)
-            ?? $event->nonAttributableAllowableCost;
+        $this->currency ??= $event->nonAttributableAllowableCostChange->currency;
+        $this->nonAttributableAllowableCost = $event->newNonAttributableAllowableCost;
     }
 
     /** @throws TaxYearException */

--- a/domain/src/Aggregates/TaxYear/TaxYear.php
+++ b/domain/src/Aggregates/TaxYear/TaxYear.php
@@ -70,19 +70,18 @@ class TaxYear implements AggregateRoot
             throw TaxYearException::cannotRevertCapitalGainUpdateBeforeCapitalGainIsUpdated(taxYearId: $this->aggregateRootId);
         }
 
-        $this->checkCurrency($action->capitalGain->currency(), $action);
+        $this->checkCurrency($action->capitalGainUpdate->currency(), $action);
 
         $this->recordThat(new CapitalGainUpdateReverted(
             date: $action->date,
-            capitalGain: $action->capitalGain,
+            capitalGainUpdate: $action->capitalGainUpdate,
+            newCapitalGain: $this->capitalGain?->minus($action->capitalGainUpdate) ?? $action->capitalGainUpdate,
         ));
     }
 
     public function applyCapitalGainUpdateReverted(CapitalGainUpdateReverted $event): void
     {
-        assert(! is_null($this->capitalGain));
-
-        $this->capitalGain = $this->capitalGain->minus($event->capitalGain);
+        $this->capitalGain = $event->newCapitalGain;
     }
 
     /** @throws TaxYearException */

--- a/domain/src/Aggregates/TaxYear/TaxYear.php
+++ b/domain/src/Aggregates/TaxYear/TaxYear.php
@@ -87,18 +87,19 @@ class TaxYear implements AggregateRoot
     /** @throws TaxYearException */
     public function updateIncome(UpdateIncome $action): void
     {
-        $this->checkCurrency($action->income->currency, $action);
+        $this->checkCurrency($action->incomeUpdate->currency, $action);
 
         $this->recordThat(new IncomeUpdated(
             date: $action->date,
-            income: $action->income,
+            incomeUpdate: $action->incomeUpdate,
+            newIncome: $this->income?->plus($action->incomeUpdate) ?? $action->incomeUpdate,
         ));
     }
 
     public function applyIncomeUpdated(IncomeUpdated $event): void
     {
-        $this->currency ??= $event->income->currency;
-        $this->income = $this->income?->plus($event->income) ?? $event->income;
+        $this->currency ??= $event->incomeUpdate->currency;
+        $this->income = $event->newIncome;
     }
 
     /** @throws TaxYearException */

--- a/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
@@ -20,11 +20,6 @@ final readonly class CapitalGain implements JsonSerializable, Stringable
         $this->difference = $proceeds->minus($costBasis);
     }
 
-    public function opposite(): self
-    {
-        return new self($this->costBasis->opposite(), $this->proceeds->opposite());
-    }
-
     public function isGain(): bool
     {
         return $this->difference->isPositive();

--- a/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/CapitalGain.php
@@ -47,6 +47,22 @@ final readonly class CapitalGain implements JsonSerializable, Stringable
         return $this->difference->currency;
     }
 
+    public function plus(CapitalGain $capitalGain): self
+    {
+        return new self(
+            costBasis: $this->costBasis->plus($capitalGain->costBasis),
+            proceeds: $this->proceeds->plus($capitalGain->proceeds),
+        );
+    }
+
+    public function minus(CapitalGain $capitalGain): self
+    {
+        return new self(
+            costBasis: $this->costBasis->minus($capitalGain->costBasis),
+            proceeds: $this->proceeds->minus($capitalGain->proceeds),
+        );
+    }
+
     /** @return array{cost_basis:string,proceeds:string,difference:string} */
     public function jsonSerialize(): array
     {

--- a/domain/src/Services/Math/Math.php
+++ b/domain/src/Services/Math/Math.php
@@ -41,7 +41,7 @@ final class Math
      */
     public static function sub(string ...$operands): string
     {
-        if (empty($initial = array_shift($operands))) {
+        if (is_null($initial = array_shift($operands))) {
             return '0';
         }
 

--- a/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/IncomeHandler.php
@@ -22,7 +22,7 @@ class IncomeHandler
 
         $this->runner->run(new UpdateIncome(
             date: $transaction->date,
-            income: $transaction->marketValue,
+            incomeUpdate: $transaction->marketValue,
         ));
     }
 }

--- a/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
+++ b/domain/src/Services/TransactionDispatcher/Handlers/TransferHandler.php
@@ -24,7 +24,7 @@ class TransferHandler
 
         $this->runner->run(new UpdateNonAttributableAllowableCost(
             date: $transaction->date,
-            nonAttributableAllowableCost: $transaction->fee->marketValue,
+            nonAttributableAllowableCostChange: $transaction->fee->marketValue,
         ));
     }
 }

--- a/domain/src/ValueObjects/FiatAmount.php
+++ b/domain/src/ValueObjects/FiatAmount.php
@@ -31,11 +31,6 @@ final readonly class FiatAmount implements Stringable
         return new self(Quantity::zero(), $this->currency);
     }
 
-    public function opposite(): FiatAmount
-    {
-        return new self($this->quantity->opposite(), $this->currency);
-    }
-
     public function isPositive(): bool
     {
         return $this->quantity->isPositive();

--- a/domain/src/ValueObjects/Quantity.php
+++ b/domain/src/ValueObjects/Quantity.php
@@ -38,13 +38,6 @@ final readonly class Quantity implements Stringable
         return new Quantity($this->quantity);
     }
 
-    public function opposite(): Quantity
-    {
-        $newQuantity = str_starts_with($this->quantity, '-') ? ltrim($this->quantity, '-') : '-' . $this->quantity;
-
-        return new Quantity($newQuantity);
-    }
-
     public function isPositive(): bool
     {
         return Math::gte($this->quantity, '0');

--- a/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
@@ -102,6 +102,7 @@ it('can increase the cost basis of a non-fungible asset', function () {
     $nonFungibleAssetCostBasisIncreased = new NonFungibleAssetCostBasisIncreased(
         date: $increaseNonFungibleAssetCostBasis->date,
         costBasisIncrease: $increaseNonFungibleAssetCostBasis->costBasisIncrease,
+        newCostBasis: FiatAmount::GBP('150'),
     );
 
     /** @var AggregateRootTestCase $this */

--- a/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Reactors/NonFungibleAssetReactorTest.php
@@ -22,7 +22,7 @@ it('can handle a capital gain', function () {
         ->when(new Message($nonFungibleAssetDisposedOf))
         ->then(fn () => $this->runner->shouldHaveReceived(
             'run',
-            fn (UpdateCapitalGain $action) => $action->capitalGain->difference->isEqualTo('1'),
+            fn (UpdateCapitalGain $action) => $action->capitalGainUpdate->difference->isEqualTo('1'),
         )->once());
 });
 
@@ -38,6 +38,6 @@ it('can handle a capital loss', function () {
         ->when(new Message($nonFungibleAssetDisposedOf))
         ->then(fn () => $this->runner->shouldHaveReceived(
             'run',
-            fn (UpdateCapitalGain $action) => $action->capitalGain->difference->isEqualTo('-1'),
+            fn (UpdateCapitalGain $action) => $action->capitalGainUpdate->difference->isEqualTo('-1'),
         )->once());
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
@@ -48,7 +48,7 @@ it('can handle a capital gain update reversion', function (string $costBasis, st
         ->when(new Message($sharePoolingAssetDisposalReverted))
         ->then(fn () => $this->runner->shouldHaveReceived(
             'run',
-            fn (RevertCapitalGainUpdate $action) => $action->capitalGain->difference->isEqualTo($capitalGain)
+            fn (RevertCapitalGainUpdate $action) => $action->capitalGainUpdate->difference->isEqualTo($capitalGain)
         )->once());
 })->with([
     'gain' => ['100', '101', '1'],

--- a/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Reactors/SharePoolingAssetReactorTest.php
@@ -27,7 +27,7 @@ it('can handle a capital gain update', function (string $costBasis, string $proc
         ->when(new Message($sharePoolingAssetDisposedOf))
         ->then(fn () => $this->runner->shouldHaveReceived(
             'run',
-            fn (UpdateCapitalGain $action) => $action->capitalGain->difference->isEqualTo($capitalGain)
+            fn (UpdateCapitalGain $action) => $action->capitalGainUpdate->difference->isEqualTo($capitalGain)
         )->once());
 })->with([
     'gain' => ['100', '101', '1'],

--- a/domain/tests/Aggregates/TaxYear/Actions/RevertCapitalGainUpdateTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/RevertCapitalGainUpdateTest.php
@@ -13,7 +13,7 @@ it('can revert a capital gain update', function () {
 
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(
+        capitalGainUpdate: new CapitalGain(
             costBasis: FiatAmount::GBP('1'),
             proceeds: FiatAmount::GBP('2'),
         )

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateCapitalGainTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateCapitalGainTest.php
@@ -13,7 +13,7 @@ it('can update the capital gain', function () {
 
     $updateCapitalGain = new UpdateCapitalGain(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(
+        capitalGainUpdate: new CapitalGain(
             costBasis: FiatAmount::GBP('1'),
             proceeds: FiatAmount::GBP('2'),
         )

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateIncomeTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateIncomeTest.php
@@ -12,7 +12,7 @@ it('can update the income', function () {
 
     $updateIncome = new UpdateIncome(
         date: LocalDate::parse('2015-10-21'),
-        income: FiatAmount::GBP('1'),
+        incomeUpdate: FiatAmount::GBP('1'),
     );
 
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCostTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCostTest.php
@@ -12,7 +12,7 @@ it('can update the non-attributable allowable cost', function () {
 
     $updateNonAttributableAllowableCost = new UpdateNonAttributableAllowableCost(
         date: LocalDate::parse('2015-10-21'),
-        nonAttributableAllowableCost: FiatAmount::GBP('1'),
+        nonAttributableAllowableCostChange: FiatAmount::GBP('1'),
     );
 
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -78,7 +78,8 @@ it('can handle an income update', function () {
 it('can handle a non-attributable allowable cost update', function () {
     $nonAttributableAllowableCostUpdated = new NonAttributableAllowableCostUpdated(
         date: LocalDate::parse('2015-10-21'),
-        nonAttributableAllowableCost: FiatAmount::GBP('100'),
+        nonAttributableAllowableCostChange: FiatAmount::GBP('100'),
+        newNonAttributableAllowableCost: FiatAmount::GBP('100'),
     );
 
     /** @var MessageConsumerTestCase $this */
@@ -86,6 +87,6 @@ it('can handle a non-attributable allowable cost update', function () {
         ->when(new Message($nonAttributableAllowableCostUpdated))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('updateNonAttributableAllowableCost')
             ->withArgs(fn (AggregateRootId $taxYearId, FiatAmount $nonAttributableAllowableCost) => $taxYearId->toString() === $this->aggregateRootId->toString()
-                && $nonAttributableAllowableCost === $nonAttributableAllowableCostUpdated->nonAttributableAllowableCost)
+                && $nonAttributableAllowableCost === $nonAttributableAllowableCostUpdated->nonAttributableAllowableCostChange)
             ->once());
 });

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -16,9 +16,12 @@ use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
 uses(TaxYearSummaryProjectorTestCase::class);
 
 it('can handle a capital gain update', function (string $costBasis, string $proceeds, string $capitalGainDifference) {
+    $capitalGainUpdate = new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds));
+
     $capitalGainUpdated = new CapitalGainUpdated(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
+        capitalGainUpdate: $capitalGainUpdate,
+        newCapitalGain: $capitalGainUpdate,
     );
 
     /** @var MessageConsumerTestCase $this */
@@ -26,7 +29,7 @@ it('can handle a capital gain update', function (string $costBasis, string $proc
         ->when(new Message($capitalGainUpdated))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('updateCapitalGain')
             ->withArgs(fn (AggregateRootId $taxYearId, CapitalGain $capitalGain) => $taxYearId->toString() === $this->aggregateRootId->toString()
-                && $capitalGain->isEqualTo($capitalGainUpdated->capitalGain)
+                && $capitalGain->isEqualTo($capitalGainUpdated->capitalGainUpdate)
                 && (string) $capitalGain->difference->quantity === $capitalGainDifference)
             ->once());
 })->with([

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -62,7 +62,8 @@ it('can handle a capital gain update reversion', function (string $costBasis, st
 it('can handle an income update', function () {
     $incomeUpdated = new IncomeUpdated(
         date: LocalDate::parse('2015-10-21'),
-        income: FiatAmount::GBP('100'),
+        incomeUpdate: FiatAmount::GBP('100'),
+        newIncome: FiatAmount::GBP('100'),
     );
 
     /** @var MessageConsumerTestCase $this */
@@ -70,7 +71,7 @@ it('can handle an income update', function () {
         ->when(new Message($incomeUpdated))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('updateIncome')
             ->withArgs(fn (AggregateRootId $taxYearId, FiatAmount $income) => $taxYearId->toString() === $this->aggregateRootId->toString()
-                && $income === $incomeUpdated->income)
+                && $income === $incomeUpdated->incomeUpdate)
             ->once());
 });
 

--- a/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
+++ b/domain/tests/Aggregates/TaxYear/Projectors/TaxYearSummaryProjectorTest.php
@@ -38,9 +38,12 @@ it('can handle a capital gain update', function (string $costBasis, string $proc
 ]);
 
 it('can handle a capital gain update reversion', function (string $costBasis, string $proceeds, string $capitalGainDifference) {
+    $capitalGainUpdate = new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds));
+
     $capitalGainUpdateReverted = new CapitalGainUpdateReverted(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
+        capitalGainUpdate: $capitalGainUpdate,
+        newCapitalGain: $capitalGainUpdate,
     );
 
     /** @var MessageConsumerTestCase $this */
@@ -48,7 +51,7 @@ it('can handle a capital gain update reversion', function (string $costBasis, st
         ->when(new Message($capitalGainUpdateReverted))
         ->then(fn () => $this->taxYearSummaryRepository->shouldHaveReceived('updateCapitalGain')
             ->withArgs(fn (AggregateRootId $taxYearId, CapitalGain $capitalGain) => $taxYearId->toString() === $this->aggregateRootId->toString()
-                && $capitalGain->isEqualTo($capitalGainUpdateReverted->capitalGain->opposite())
+                && $capitalGain->isEqualTo($capitalGainUpdateReverted->capitalGainUpdate->opposite())
                 && (string) $capitalGain->difference->quantity === (string) (new Quantity($capitalGainDifference))->opposite())
             ->once());
 })->with([

--- a/domain/tests/Aggregates/TaxYear/TaxYearTest.php
+++ b/domain/tests/Aggregates/TaxYear/TaxYearTest.php
@@ -76,12 +76,13 @@ it('can revert a capital gain update', function (string $costBasis, string $proc
 
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
+        capitalGainUpdate: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
     );
 
     $capitalGainReverted = new CapitalGainUpdateReverted(
         date: $revertCapitalGainUpdate->date,
-        capitalGain: $revertCapitalGainUpdate->capitalGain,
+        capitalGainUpdate: $revertCapitalGainUpdate->capitalGainUpdate,
+        newCapitalGain: new CapitalGain(FiatAmount::GBP(0), FiatAmount::GBP(0)),
     );
 
     /** @var AggregateRootTestCase $this */
@@ -96,7 +97,7 @@ it('can revert a capital gain update', function (string $costBasis, string $proc
 it('cannot revert a capital gain update before the capital gain was updated', function () {
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150')),
+        capitalGainUpdate: new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150')),
     );
 
     $cannotRevertCapitalGain = TaxYearException::cannotRevertCapitalGainUpdateBeforeCapitalGainIsUpdated(
@@ -119,7 +120,7 @@ it('cannot revert a capital gain update because the currencies don\'t match', fu
 
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(new FiatAmount('50', FiatCurrency::EUR), new FiatAmount('150', FiatCurrency::EUR)),
+        capitalGainUpdate: new CapitalGain(new FiatAmount('50', FiatCurrency::EUR), new FiatAmount('150', FiatCurrency::EUR)),
     );
 
     $cannotRevertCapitalGainUpdate = TaxYearException::currencyMismatch(

--- a/domain/tests/Aggregates/TaxYear/TaxYearTest.php
+++ b/domain/tests/Aggregates/TaxYear/TaxYearTest.php
@@ -181,12 +181,13 @@ it('cannot update the income because the currencies don\'t match', function () {
 it('can update the non-attributable allowable cost', function () {
     $updateNonAttributableAllowableCost = new UpdateNonAttributableAllowableCost(
         date: LocalDate::parse('2015-10-21'),
-        nonAttributableAllowableCost: FiatAmount::GBP('100'),
+        nonAttributableAllowableCostChange: FiatAmount::GBP('100'),
     );
 
     $nonAttributableAllowableCostUpdated = new NonAttributableAllowableCostUpdated(
         date: $updateNonAttributableAllowableCost->date,
-        nonAttributableAllowableCost: $updateNonAttributableAllowableCost->nonAttributableAllowableCost,
+        nonAttributableAllowableCostChange: $updateNonAttributableAllowableCost->nonAttributableAllowableCostChange,
+        newNonAttributableAllowableCost: $updateNonAttributableAllowableCost->nonAttributableAllowableCostChange,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -197,12 +198,13 @@ it('can update the non-attributable allowable cost', function () {
 it('cannot update the non-attributable allowable cost because the currencies don\'t match', function () {
     $nonAttributableAllowableCostUpdated = new NonAttributableAllowableCostUpdated(
         date: LocalDate::parse('2015-10-21'),
-        nonAttributableAllowableCost: FiatAmount::GBP('100'),
+        nonAttributableAllowableCostChange: FiatAmount::GBP('100'),
+        newNonAttributableAllowableCost: FiatAmount::GBP('100'),
     );
 
     $updateNonAttributableAllowableCost = new UpdateNonAttributableAllowableCost(
         date: LocalDate::parse('2015-10-21'),
-        nonAttributableAllowableCost: new FiatAmount('100', FiatCurrency::EUR),
+        nonAttributableAllowableCostChange: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     $cannotUpdateNonAttributableAllowableCost = TaxYearException::currencyMismatch(

--- a/domain/tests/Aggregates/TaxYear/TaxYearTest.php
+++ b/domain/tests/Aggregates/TaxYear/TaxYearTest.php
@@ -21,12 +21,13 @@ uses(TaxYearTestCase::class);
 it('can update the capital gain', function (string $costBasis, string $proceeds) {
     $updateCapitalGain = new UpdateCapitalGain(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
+        capitalGainUpdate: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
     );
 
     $capitalGainUpdated = new CapitalGainUpdated(
         date: $updateCapitalGain->date,
-        capitalGain: $updateCapitalGain->capitalGain,
+        capitalGainUpdate: $updateCapitalGain->capitalGainUpdate,
+        newCapitalGain: $updateCapitalGain->capitalGainUpdate,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -38,14 +39,17 @@ it('can update the capital gain', function (string $costBasis, string $proceeds)
 ]);
 
 it('cannot update the capital gain because the currencies don\'t match', function () {
+    $capitalGainUpdate = new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150'));
+
     $capitalGainUpdated = new CapitalGainUpdated(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150')),
+        capitalGainUpdate: $capitalGainUpdate,
+        newCapitalGain: $capitalGainUpdate,
     );
 
     $updateCapitalGain = new UpdateCapitalGain(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(new FiatAmount('50', FiatCurrency::EUR), new FiatAmount('150', FiatCurrency::EUR)),
+        capitalGainUpdate: new CapitalGain(new FiatAmount('50', FiatCurrency::EUR), new FiatAmount('150', FiatCurrency::EUR)),
     );
 
     $cannotUpdateCapitalGain = TaxYearException::currencyMismatch(
@@ -62,9 +66,12 @@ it('cannot update the capital gain because the currencies don\'t match', functio
 });
 
 it('can revert a capital gain update', function (string $costBasis, string $proceeds) {
+    $capitalGainUpdate = new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds));
+
     $capitalGainUpdated = new CapitalGainUpdated(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP($costBasis), FiatAmount::GBP($proceeds)),
+        capitalGainUpdate: $capitalGainUpdate,
+        newCapitalGain: $capitalGainUpdate,
     );
 
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(
@@ -102,9 +109,12 @@ it('cannot revert a capital gain update before the capital gain was updated', fu
 });
 
 it('cannot revert a capital gain update because the currencies don\'t match', function () {
+    $capitalGainUpdate = new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150'));
+
     $capitalGainUpdated = new CapitalGainUpdated(
         date: LocalDate::parse('2015-10-21'),
-        capitalGain: new CapitalGain(FiatAmount::GBP('50'), FiatAmount::GBP('150')),
+        capitalGainUpdate: $capitalGainUpdate,
+        newCapitalGain: $capitalGainUpdate,
     );
 
     $revertCapitalGainUpdate = new RevertCapitalGainUpdate(

--- a/domain/tests/Aggregates/TaxYear/TaxYearTest.php
+++ b/domain/tests/Aggregates/TaxYear/TaxYearTest.php
@@ -139,12 +139,13 @@ it('cannot revert a capital gain update because the currencies don\'t match', fu
 it('can update the income', function () {
     $updateIncome = new UpdateIncome(
         date: LocalDate::parse('2015-10-21'),
-        income: FiatAmount::GBP('100'),
+        incomeUpdate: FiatAmount::GBP('100'),
     );
 
     $incomeUpdated = new IncomeUpdated(
         date: $updateIncome->date,
-        income: $updateIncome->income,
+        incomeUpdate: $updateIncome->incomeUpdate,
+        newIncome: $updateIncome->incomeUpdate,
     );
 
     /** @var AggregateRootTestCase $this */
@@ -155,12 +156,13 @@ it('can update the income', function () {
 it('cannot update the income because the currencies don\'t match', function () {
     $incomeUpdated = new IncomeUpdated(
         date: LocalDate::parse('2015-10-21'),
-        income: FiatAmount::GBP('100'),
+        incomeUpdate: FiatAmount::GBP('100'),
+        newIncome: FiatAmount::GBP('100'),
     );
 
     $updateIncome = new UpdateIncome(
         date: LocalDate::parse('2015-10-21'),
-        income: new FiatAmount('100', FiatCurrency::EUR),
+        incomeUpdate: new FiatAmount('100', FiatCurrency::EUR),
     );
 
     $cannotUpdateIncome = TaxYearException::currencyMismatch(

--- a/domain/tests/Aggregates/TaxYear/ValueObjects/CapitalGainTest.php
+++ b/domain/tests/Aggregates/TaxYear/ValueObjects/CapitalGainTest.php
@@ -15,18 +15,6 @@ it('can instantiate a capital gain and return whether it is a gain or a loss', f
     'zero' => ['1', '1', '0', true, false],
 ]);
 
-it('can return a capital gain with opposite quantities', function (string $from, string $to) {
-    $capitalGain = (new CapitalGain(FiatAmount::GBP($from), FiatAmount::GBP($from)))->opposite();
-
-    expect((string) $capitalGain->costBasis->quantity)->toBe($to);
-    expect((string) $capitalGain->proceeds->quantity)->toBe($to);
-    expect((string) $capitalGain->difference->quantity)->toBe('0');
-})->with([
-    'positive' => ['1', '-1'],
-    'negative' => ['-1', '1'],
-    'zero' => ['0', '-0'],
-]);
-
 it('can tell whether two capital gains are equal', function (string $costBasis1, string $proceeds1, string $costBasis2, string $proceeds2, bool $result) {
     $capitalGain1 = new CapitalGain(FiatAmount::GBP($costBasis1), FiatAmount::GBP($proceeds1));
     $capitalGain2 = new CapitalGain(FiatAmount::GBP($costBasis2), FiatAmount::GBP($proceeds2));

--- a/domain/tests/Aggregates/TaxYear/ValueObjects/CapitalGainTest.php
+++ b/domain/tests/Aggregates/TaxYear/ValueObjects/CapitalGainTest.php
@@ -41,3 +41,39 @@ it('can tell whether two capital gains are equal', function (string $costBasis1,
     'scenario 6' => ['2', '1', '2', '1', true],
     'scenario 7' => ['3', '2', '2', '1', false],
 ]);
+
+it('can add a capital gain to another one', function (array $quantities1, array $quantities2, array $result) {
+    $capitalGain1 = new CapitalGain(FiatAmount::GBP($quantities1[0]), FiatAmount::GBP($quantities1[1]));
+    $capitalGain2 = new CapitalGain(FiatAmount::GBP($quantities2[0]), FiatAmount::GBP($quantities2[1]));
+
+    $capitalGain = $capitalGain1->plus($capitalGain2);
+
+    expect((string) $capitalGain->costBasis->quantity)->toBe($result[0]);
+    expect((string) $capitalGain->proceeds->quantity)->toBe($result[1]);
+    expect((string) $capitalGain->difference->quantity)->toBe($result[2]);
+})->with([
+    'scenario 1' => [['1', '1'], ['1', '1'], ['2', '2', '0']],
+    'scenario 2' => [['-1', '-1'], ['-1', '-1'], ['-2', '-2', '0']],
+    'scenario 3' => [['0', '0'], ['0', '0'], ['0', '0', '0']],
+    'scenario 4' => [['-0', '-0'], ['-0', '-0'], ['0', '0', '0']],
+    'scenario 5' => [['1', '1'], ['0', '1'], ['1', '2', '1']],
+    'scenario 6' => [['1', '1'], ['1', '0'], ['2', '1', '-1']],
+]);
+
+it('can substract a capital gain from another one', function (array $quantities1, array $quantities2, array $result) {
+    $capitalGain1 = new CapitalGain(FiatAmount::GBP($quantities1[0]), FiatAmount::GBP($quantities1[1]));
+    $capitalGain2 = new CapitalGain(FiatAmount::GBP($quantities2[0]), FiatAmount::GBP($quantities2[1]));
+
+    $capitalGain = $capitalGain1->minus($capitalGain2);
+
+    expect((string) $capitalGain->costBasis->quantity)->toBe($result[0]);
+    expect((string) $capitalGain->proceeds->quantity)->toBe($result[1]);
+    expect((string) $capitalGain->difference->quantity)->toBe($result[2]);
+})->with([
+    'scenario 1' => [['1', '1'], ['1', '1'], ['0', '0', '0']],
+    'scenario 2' => [['-1', '-1'], ['-1', '-1'], ['0', '0', '0']],
+    'scenario 3' => [['0', '0'], ['0', '0'], ['0', '0', '0']],
+    'scenario 4' => [['-0', '-0'], ['-0', '-0'], ['0', '0', '0']],
+    'scenario 5' => [['1', '1'], ['0', '1'], ['1', '0', '-1']],
+    'scenario 6' => [['1', '1'], ['1', '0'], ['0', '1', '1']],
+]);

--- a/domain/tests/Services/Math/MathTest.php
+++ b/domain/tests/Services/Math/MathTest.php
@@ -19,11 +19,12 @@ it('can subtract', function (array $operands, string $result) {
 })->with([
     'scenario 1' => [['1', '1'], '0'],
     'scenario 2' => [['1', '-1'], '2'],
-    'scenario 3' => [['1', '1', '1'], '-1'],
-    'scenario 4' => [['3.33', '1.11'], '2.22'],
-    'scenario 5' => [['-3.33', '1.11'], '-4.44'],
-    'scenario 6' => [['2.246913569', '1.123456789'], '1.12345678'],
-    'scenario 7' => [['2.2222223', '1.11111111'], '1.11111119'],
+    'scenario 4' => [['0', '1'], '-1'],
+    'scenario 5' => [['1', '1', '1'], '-1'],
+    'scenario 6' => [['3.33', '1.11'], '2.22'],
+    'scenario 7' => [['-3.33', '1.11'], '-4.44'],
+    'scenario 8' => [['2.246913569', '1.123456789'], '1.12345678'],
+    'scenario 9' => [['2.2222223', '1.11111111'], '1.11111119'],
 ]);
 
 it('can multiply', function (string $multiplicand, string $multiplier, string $result) {

--- a/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/IncomeHandlerTest.php
@@ -19,7 +19,7 @@ it('can handle an income transaction', function () {
 
     $this->runner->shouldHaveReceived(
         'run',
-        fn (UpdateIncome $action) => $action->income->isEqualTo($transaction->marketValue),
+        fn (UpdateIncome $action) => $action->incomeUpdate->isEqualTo($transaction->marketValue),
     )->once();
 });
 

--- a/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
+++ b/domain/tests/Services/TransactionDispatcher/Handlers/TransferHandlerTest.php
@@ -18,7 +18,7 @@ it('can handle a transfer operation', function () {
 
     $this->runner->shouldHaveReceived(
         'run',
-        fn (UpdateNonAttributableAllowableCost $action) => $action->nonAttributableAllowableCost->isEqualTo($fee),
+        fn (UpdateNonAttributableAllowableCost $action) => $action->nonAttributableAllowableCostChange->isEqualTo($fee),
     )->once();
 });
 

--- a/domain/tests/ValueObjects/FiatAmountTest.php
+++ b/domain/tests/ValueObjects/FiatAmountTest.php
@@ -21,13 +21,6 @@ it('can return a fiat amount with a zero quantity', function () {
     $this->assertEquals($amount->currency, FiatCurrency::GBP);
 });
 
-it('can return a fiat amount with the opposite quantity', function (string $from, string $to) {
-    expect((string) FiatAmount::GBP($from)->opposite()->quantity)->toBe($to);
-})->with([
-    'positive' => ['1', '-1'],
-    'negative' => ['-1', '1'],
-]);
-
 it('can tell whether a fiat amount is positive', function (string $quantity, bool $result) {
     expect(FiatAmount::GBP($quantity)->isPositive())->toBe($result);
 })->with([

--- a/domain/tests/ValueObjects/QuantityTest.php
+++ b/domain/tests/ValueObjects/QuantityTest.php
@@ -56,13 +56,6 @@ it('can copy a quantity', function (string $quantity) {
     expect($quantity2)->not->toBe($quantity1);
 })->with(['1', '-1']);
 
-it('can return the opposite of a quantity', function (string $from, string $to) {
-    expect((new Quantity($from))->opposite()->quantity)->toBe($to);
-})->with([
-    'positive' => ['1', '-1'],
-    'negative' => ['-1', '1'],
-]);
-
 it('can tell whether a quantity is positive', function (string $quantity, bool $result) {
     expect((new Quantity($quantity))->isPositive())->toBe($result);
 })->with([

--- a/tests/Feature/Aggregates/TaxYear/Repositories/TaxYearSummaryRepositoryTest.php
+++ b/tests/Feature/Aggregates/TaxYear/Repositories/TaxYearSummaryRepositoryTest.php
@@ -81,7 +81,7 @@ it('can retrieve an existing tax year summary and update its capital gain', func
         ]),
     ]);
 
-    $capitalGain = new CapitalGain(costBasis: FiatAmount::GBP('100'), proceeds: FiatAmount::GBP('150'));
+    $capitalGain = new CapitalGain(costBasis: FiatAmount::GBP('200'), proceeds: FiatAmount::GBP('250'));
 
     $this->taxYearSummaryRepository->updateCapitalGain($this->taxYearId, $capitalGain);
 
@@ -113,7 +113,7 @@ it('can retrieve an existing tax year summary and update its income', function (
         'income' => '100',
     ]);
 
-    $this->taxYearSummaryRepository->updateIncome($this->taxYearId, FiatAmount::GBP('100'));
+    $this->taxYearSummaryRepository->updateIncome($this->taxYearId, FiatAmount::GBP('200'));
 
     $this->assertDatabaseCount('tax_year_summaries', 1);
     $this->assertDatabaseHas('tax_year_summaries', [
@@ -139,7 +139,7 @@ it('can retrieve an existing tax year summary and update its non-attributable al
         'non_attributable_allowable_cost' => '100',
     ]);
 
-    $this->taxYearSummaryRepository->updateNonAttributableAllowableCost($this->taxYearId, FiatAmount::GBP('100'));
+    $this->taxYearSummaryRepository->updateNonAttributableAllowableCost($this->taxYearId, FiatAmount::GBP('200'));
 
     $this->assertDatabaseCount('tax_year_summaries', 1);
     $this->assertDatabaseHas('tax_year_summaries', [


### PR DESCRIPTION
## Summary

This PR moves some calculations from the event's application method to the event itself in the aggregates.

## Explanation

It is good practice to add computed values to the events as to not duplicate the calculation logic in both the aggregate root and at the consumer-level.

Changes:

* The `NonFungibleAssetCostBasisIncreased` now holds the new total cost basis;
* The `CapitalGainUpdated` now holds the new total capital gain;
* The `CapitalGainUpdateReverted` now holds the new total capital gain;
* The `IncomeUpdated` now holds the new total income; and
* The `NonAttributableAllowableCostUpdated` now holds the new total non-attributable allowable cost.

The above allowed me to use the events' computed values from the `TaxYearSummaryProjector` projector instead of having to perform those calculations again in the `TaxYearSummary` projection.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
