### PR TITLE
Use of the Pest utilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpoffice/phpspreadsheet": "^1.28"
     },
     "require-dev": {
-        "eventsauce/test-utilities": "^3.3",
+        "eventsauce/pest-utilities": "^3.4",
         "fakerphp/faker": "^1.21.0",
         "intonate/tinker-zero": "^1.2",
         "laravel/pint": "^1.6",

--- a/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/NonFungibleAssetTest.php
@@ -12,285 +12,168 @@ use Domain\Enums\FiatCurrency;
 use Domain\Tests\Aggregates\NonFungibleAsset\NonFungibleAssetTestCase;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
-use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
+
+use function EventSauce\EventSourcing\PestTooling\expectToFail;
+use function EventSauce\EventSourcing\PestTooling\given;
+use function EventSauce\EventSourcing\PestTooling\then;
+use function EventSauce\EventSourcing\PestTooling\when;
 
 uses(NonFungibleAssetTestCase::class);
 
 it('can acquire a non-fungible asset', function () {
-    // When
-
-    $acquireNonFungibleAsset = new AcquireNonFungibleAsset(
+    when($acquireNonFungibleAsset = new AcquireNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+    then(new NonFungibleAssetAcquired(
         date: $acquireNonFungibleAsset->date,
         costBasis: $acquireNonFungibleAsset->costBasis,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->when($acquireNonFungibleAsset)
-        ->then($nonFungibleAssetAcquired);
+    ));
 });
 
 it('cannot acquire a non-fungible asset because the asset is fungible', function () {
-    // When
-
-    $acquireNonFungibleAsset = new AcquireNonFungibleAsset(
+    when($acquireNonFungibleAsset = new AcquireNonFungibleAsset(
         asset: new Asset('FOO'),
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $assetIsFungible = NonFungibleAssetException::assetIsFungible($acquireNonFungibleAsset);
-
-    /** @var AggregateRootTestCase $this */
-    $this->when($acquireNonFungibleAsset)
-        ->expectToFail($assetIsFungible);
+    expectToFail(NonFungibleAssetException::assetIsFungible($acquireNonFungibleAsset));
 });
 
 it('cannot acquire the same non-fungible asset more than once', function () {
-    // Given
+    given(new NonFungibleAssetAcquired(date: LocalDate::parse('2015-10-21'), costBasis: FiatAmount::GBP('100')));
 
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
-        date: LocalDate::parse('2015-10-21'),
-        costBasis: FiatAmount::GBP('100'),
-    );
-
-    // When
-
-    $acquireSameNonFungibleAsset = new AcquireNonFungibleAsset(
+    when(new AcquireNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $alreadyAcquired = NonFungibleAssetException::alreadyAcquired($this->aggregateRootId->toAsset());
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($acquireSameNonFungibleAsset)
-        ->expectToFail($alreadyAcquired);
+    expectToFail(NonFungibleAssetException::alreadyAcquired($this->aggregateRootId->toAsset()));
 });
 
 it('can increase the cost basis of a non-fungible asset', function () {
-    // Given
+    given(new NonFungibleAssetAcquired(date: LocalDate::parse('2015-10-21'), costBasis: FiatAmount::GBP('100')));
 
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
-        date: LocalDate::parse('2015-10-21'),
-        costBasis: FiatAmount::GBP('100'),
-    );
-
-    // When
-
-    $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
+    when($increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: FiatAmount::GBP('50'),
-    );
+    ));
 
-    // Then
-
-    $nonFungibleAssetCostBasisIncreased = new NonFungibleAssetCostBasisIncreased(
+    then(new NonFungibleAssetCostBasisIncreased(
         date: $increaseNonFungibleAssetCostBasis->date,
         costBasisIncrease: $increaseNonFungibleAssetCostBasis->costBasisIncrease,
         newCostBasis: FiatAmount::GBP('150'),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($increaseNonFungibleAssetCostBasis)
-        ->then($nonFungibleAssetCostBasisIncreased);
+    ));
 });
 
 it('cannot increase the cost basis of a non-fungible asset that has not been acquired', function () {
-    // When
-
-    $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
+    when(new IncreaseNonFungibleAssetCostBasis(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotIncreaseCostBasis = NonFungibleAssetException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId->toAsset());
-
-    /** @var AggregateRootTestCase $this */
-    $this->when($increaseNonFungibleAssetCostBasis)
-        ->expectToFail($cannotIncreaseCostBasis);
+    expectToFail(NonFungibleAssetException::cannotIncreaseCostBasisBeforeAcquisition($this->aggregateRootId->toAsset()));
 });
 
 it('cannot increase the cost basis of a non-fungible asset because the transaction is older than the previous one', function () {
-    // Given
-
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+    given($nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // When
-
-    $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
+    when($increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-20'),
         costBasisIncrease: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotIncreaseCostBasis = NonFungibleAssetException::olderThanPreviousTransaction(
+    expectToFail(NonFungibleAssetException::olderThanPreviousTransaction(
         action: $increaseNonFungibleAssetCostBasis,
         previousTransactionDate: $nonFungibleAssetAcquired->date,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($increaseNonFungibleAssetCostBasis)
-        ->expectToFail($cannotIncreaseCostBasis);
+    ));
 });
 
 it('cannot increase the cost basis of a non-fungible asset because the currency is different', function () {
-    // Given
+    given(new NonFungibleAssetAcquired(date: LocalDate::parse('2015-10-21'), costBasis: FiatAmount::GBP('100')));
 
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
-        date: LocalDate::parse('2015-10-21'),
-        costBasis: FiatAmount::GBP('100'),
-    );
-
-    // When
-
-    $increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
+    when($increaseNonFungibleAssetCostBasis = new IncreaseNonFungibleAssetCostBasis(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         costBasisIncrease: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    ));
 
-    // Then
-
-    $cannotIncreaseCostBasis = NonFungibleAssetException::currencyMismatch(
+    expectToFail(NonFungibleAssetException::currencyMismatch(
         action: $increaseNonFungibleAssetCostBasis,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($increaseNonFungibleAssetCostBasis)
-        ->expectToFail($cannotIncreaseCostBasis);
+    ));
 });
 
 it('can dispose of a non-fungible asset', function () {
-    // Given
-
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+    given($nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // When
-
-    $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
+    when($disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         proceeds: FiatAmount::GBP('150'),
-    );
+    ));
 
-    // Then
-
-    $nonFungibleAssetDisposedOf = new NonFungibleAssetDisposedOf(
+    then(new NonFungibleAssetDisposedOf(
         date: $disposeOfNonFungibleAsset->date,
         costBasis: $nonFungibleAssetAcquired->costBasis,
         proceeds: $disposeOfNonFungibleAsset->proceeds,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($disposeOfNonFungibleAsset)
-        ->then($nonFungibleAssetDisposedOf);
+    ));
 });
 
 it('cannot dispose of a non-fungible asset that has not been acquired', function () {
-    // When
-
-    $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
+    when(new DisposeOfNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         proceeds: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotDisposeOf = NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId->toAsset());
-
-    /** @var AggregateRootTestCase $this */
-    $this->when($disposeOfNonFungibleAsset)
-        ->expectToFail($cannotDisposeOf);
+    expectToFail(NonFungibleAssetException::cannotDisposeOfBeforeAcquisition($this->aggregateRootId->toAsset()));
 });
 
 it('cannot dispose of a non-fungible asset because the currencies don\'t match', function () {
-    // Given
+    given(new NonFungibleAssetAcquired(date: LocalDate::parse('2015-10-21'), costBasis: FiatAmount::GBP('100')));
 
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
-        date: LocalDate::parse('2015-10-21'),
-        costBasis: FiatAmount::GBP('100'),
-    );
-
-    // When
-
-    $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
+    when($disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         proceeds: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    ));
 
-    // Then
-
-    $cannotIncreaseCostBasis = NonFungibleAssetException::currencyMismatch(
+    expectToFail(NonFungibleAssetException::currencyMismatch(
         action: $disposeOfNonFungibleAsset,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($disposeOfNonFungibleAsset)
-        ->expectToFail($cannotIncreaseCostBasis);
+    ));
 });
 
 it('cannot dispose of a non-fungible asset because the transaction is older than the previous one', function () {
-    // Given
-
-    $nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
+    given($nonFungibleAssetAcquired = new NonFungibleAssetAcquired(
         date: LocalDate::parse('2015-10-21'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // When
-
-    $disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
+    when($disposeOfNonFungibleAsset = new DisposeOfNonFungibleAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-20'),
         proceeds: FiatAmount::GBP('150'),
-    );
+    ));
 
-    // Then
-
-    $cannotDisposeOf = NonFungibleAssetException::olderThanPreviousTransaction(
+    expectToFail(NonFungibleAssetException::olderThanPreviousTransaction(
         action: $disposeOfNonFungibleAsset,
         previousTransactionDate: $nonFungibleAssetAcquired->date,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($nonFungibleAssetAcquired)
-        ->when($disposeOfNonFungibleAsset)
-        ->expectToFail($cannotDisposeOf);
+    ));
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
@@ -16,176 +16,134 @@ use Domain\Enums\FiatCurrency;
 use Domain\Tests\Aggregates\SharePoolingAsset\SharePoolingAssetTestCase;
 use Domain\ValueObjects\FiatAmount;
 use Domain\ValueObjects\Quantity;
-use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
+
+use function EventSauce\EventSourcing\PestTooling\expectToFail;
+use function EventSauce\EventSourcing\PestTooling\given;
+use function EventSauce\EventSourcing\PestTooling\then;
+use function EventSauce\EventSourcing\PestTooling\when;
 
 uses(SharePoolingAssetTestCase::class);
 
 it('can acquire a share pooling asset', function () {
-    // When
-
-    $acquireSharePoolingAsset = new AcquireSharePoolingAsset(
+    when($acquireSharePoolingAsset = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
-        acquisition: new SharePoolingAssetAcquisition(
-            id: $acquireSharePoolingAsset->transactionId,
-            date: $acquireSharePoolingAsset->date,
-            quantity: new Quantity('100'),
-            costBasis: $acquireSharePoolingAsset->costBasis,
+    then(
+        new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP),
+        new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireSharePoolingAsset->transactionId,
+                date: $acquireSharePoolingAsset->date,
+                quantity: new Quantity('100'),
+                costBasis: $acquireSharePoolingAsset->costBasis,
+            ),
         ),
     );
-
-    /** @var AggregateRootTestCase $this */
-    $this->when($acquireSharePoolingAsset)
-        ->then($sharePoolingAssetFiatCurrencySet, $sharePoolingAssetAcquired);
 });
 
 it('can acquire more of the same share pooling asset', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
+    when($acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: FiatAmount::GBP('300'),
-    );
+    ));
 
-    // Then
-
-    $moreSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    then(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             id: $acquireMoreSharePoolingAsset->transactionId,
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('300'),
         ),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetAcquired)
-        ->when($acquireMoreSharePoolingAsset)
-        ->then($moreSharePoolingAssetAcquired);
+    ));
 });
 
 it('cannot acquire more of the same share pooling asset because the currencies don\'t match', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
+    when($acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-21'),
         quantity: new Quantity('100'),
         costBasis: new FiatAmount('300', FiatCurrency::EUR),
-    );
+    ));
 
-    // Then
-
-    $cannotAcquireSharePoolingAsset = SharePoolingAssetException::currencyMismatch(
+    expectToFail(SharePoolingAssetException::currencyMismatch(
         action: $acquireMoreSharePoolingAsset,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetAcquired)
-        ->when($acquireMoreSharePoolingAsset)
-        ->expectToFail($cannotAcquireSharePoolingAsset);
+    ));
 });
 
 it('cannot acquire more of the same share pooling asset because the transaction is older than the previous one', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given($someSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
+    when($acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-20'),
         quantity: new Quantity('100'),
         costBasis: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotAcquireSharePoolingAsset = SharePoolingAssetException::olderThanPreviousTransaction(
+    expectToFail(SharePoolingAssetException::olderThanPreviousTransaction(
         action: $acquireMoreSharePoolingAsset,
         previousTransactionDate: $someSharePoolingAssetAcquired->acquisition->date,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetAcquired)
-        ->when($acquireMoreSharePoolingAsset)
-        ->expectToFail($cannotAcquireSharePoolingAsset);
+    ));
 });
 
 it('can dispose of a share pooling asset', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('200'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('50'),
         proceeds: FiatAmount::GBP('150'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+    then(new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             id: $disposeOfSharePoolingAsset->transactionId,
             date: $disposeOfSharePoolingAsset->date,
@@ -193,155 +151,111 @@ it('can dispose of a share pooling asset', function () {
             costBasis: FiatAmount::GBP('100'),
             proceeds: $disposeOfSharePoolingAsset->proceeds,
         ),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $sharePoolingAssetAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->then($sharePoolingAssetDisposedOf);
+    ));
 });
 
 it('cannot dispose of a share pooling asset because the currencies don\'t match', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('100'),
         proceeds: new FiatAmount('100', FiatCurrency::EUR),
-    );
+    ));
 
-    // Then
-
-    $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::currencyMismatch(
+    expectToFail(SharePoolingAssetException::currencyMismatch(
         action: $disposeOfSharePoolingAsset,
         current: FiatCurrency::GBP,
         incoming: FiatCurrency::EUR,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $sharePoolingAssetAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->expectToFail($cannotDisposeOfSharePoolingAsset);
+    ));
 });
 
 it('cannot dispose of a share pooling asset because the transaction is older than the previous one', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-20'),
         quantity: new Quantity('100'),
         proceeds: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::olderThanPreviousTransaction(
+    expectToFail(SharePoolingAssetException::olderThanPreviousTransaction(
         action: $disposeOfSharePoolingAsset,
         previousTransactionDate: $sharePoolingAssetAcquired->acquisition->date,
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $sharePoolingAssetAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->expectToFail($cannotDisposeOfSharePoolingAsset);
+    ));
 });
 
 it('cannot dispose of a share pooling asset because the quantity is too high', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('101'),
         proceeds: FiatAmount::GBP('100'),
-    );
+    ));
 
-    // Then
-
-    $cannotDisposeOfSharePoolingAsset = SharePoolingAssetException::insufficientQuantity(
+    expectToFail(SharePoolingAssetException::insufficientQuantity(
         asset: $disposeOfSharePoolingAsset->asset,
         disposalQuantity: $disposeOfSharePoolingAsset->quantity,
         availableQuantity: new Quantity('100'),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $sharePoolingAssetAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->expectToFail($cannotDisposeOfSharePoolingAsset);
+    ));
 });
 
 it('can use the average cost basis per unit of a section 104 pool to calculate the cost basis of a disposal', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-23'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('65'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-25'),
         quantity: new Quantity('20'),
         proceeds: FiatAmount::GBP('40'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+    then(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()->make([
             'id' => $disposeOfSharePoolingAsset->transactionId,
             'date' => $disposeOfSharePoolingAsset->date,
@@ -349,48 +263,37 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
             'costBasis' => FiatAmount::GBP('22'),
             'proceeds' => $disposeOfSharePoolingAsset->proceeds,
         ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetsAcquired, $moreSharePoolingAssetsAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->then($sharePoolingAssetDisposedOf);
+    ));
 });
 
 it('can dispose of a share pooling asset on the same day they were acquired', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given($moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('150'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-26'),
         quantity: new Quantity('150'),
         proceeds: FiatAmount::GBP('300'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+    then(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('100'), id: $moreSharePoolingAssetsAcquired->acquisition->id)
             ->make([
@@ -400,65 +303,54 @@ it('can dispose of a share pooling asset on the same day they were acquired', fu
                 'costBasis' => FiatAmount::GBP('200'),
                 'proceeds' => $disposeOfSharePoolingAsset->proceeds,
             ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetsAcquired, $moreSharePoolingAssetsAcquired)
-        ->when($disposeOfSharePoolingAsset)
-        ->then($sharePoolingAssetDisposedOf);
+    ));
 });
 
 it('can use the average cost basis per unit of a section 104 pool to calculate the cost basis of a disposal on the same day as an acquisition', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $moreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-23'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('65'),
         ),
-    );
+    ));
 
-    $someSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
+    given(new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-25'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('22'),
             proceeds: FiatAmount::GBP('40'),
         ),
-    );
+    ));
 
-    $evenMoreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given($evenMoreSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('30'),
             costBasis: FiatAmount::GBP('36'),
         ),
-    );
+    ));
 
-    // When
-
-    $disposeOfMoreSharePoolingAsset = new DisposeOfSharePoolingAsset(
+    when($disposeOfMoreSharePoolingAsset = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-26'),
         quantity: new Quantity('60'),
         proceeds: FiatAmount::GBP('70'),
-    );
+    ));
 
-    // Then
-
-    $moreSharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+    then(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('30'), id: $evenMoreSharePoolingAssetsAcquired->acquisition->id)
             ->make([
@@ -468,107 +360,81 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
                 'costBasis' => FiatAmount::GBP('69'),
                 'proceeds' => $disposeOfMoreSharePoolingAsset->proceeds,
             ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given(
-        $sharePoolingAssetFiatCurrencySet,
-        $someSharePoolingAssetsAcquired,
-        $moreSharePoolingAssetsAcquired,
-        $someSharePoolingAssetsDisposedOf,
-        $evenMoreSharePoolingAssetsAcquired
-    )
-        ->when($disposeOfMoreSharePoolingAsset)
-        ->then($moreSharePoolingAssetDisposedOf);
+    ));
 });
 
 it('can acquire a share pooling asset within 30 days of their disposal', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $someSharePoolingAssetsAcquired = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $someSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
+    given($someSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-26'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
             proceeds: FiatAmount::GBP('75'),
         ),
-    );
+    ));
 
-    // When
-
-    $acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
+    when($acquireMoreSharePoolingAsset = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('25'),
         costBasis: FiatAmount::GBP('20'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposalReverted = new SharePoolingAssetDisposalReverted(
-        disposal: $someSharePoolingAssetsDisposedOf->disposal,
-    );
-
-    $moreSharePoolingAssetAcquired = new SharePoolingAssetAcquired(
-        acquisition: new SharePoolingAssetAcquisition(
-            id: $acquireMoreSharePoolingAsset->transactionId,
-            date: $acquireMoreSharePoolingAsset->date,
-            quantity: $acquireMoreSharePoolingAsset->quantity,
-            costBasis: $acquireMoreSharePoolingAsset->costBasis,
-            thirtyDayQuantity: new Quantity('25'),
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $someSharePoolingAssetsDisposedOf->disposal),
+        new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireMoreSharePoolingAsset->transactionId,
+                date: $acquireMoreSharePoolingAsset->date,
+                quantity: $acquireMoreSharePoolingAsset->quantity,
+                costBasis: $acquireMoreSharePoolingAsset->costBasis,
+                thirtyDayQuantity: new Quantity('25'),
+            ),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->copyFrom($someSharePoolingAssetsDisposedOf->disposal)
+                ->withThirtyDayQuantity(new Quantity('25'), id: $acquireMoreSharePoolingAsset->transactionId)
+                ->make([
+                    'costBasis' => FiatAmount::GBP('45'),
+                    'sameDayQuantityAllocation' => new QuantityAllocation(),
+                ]),
         ),
     );
-
-    $correctedSharePoolingAssetsDisposedOf = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->copyFrom($someSharePoolingAssetsDisposedOf->disposal)
-            ->withThirtyDayQuantity(new Quantity('25'), id: $acquireMoreSharePoolingAsset->transactionId)
-            ->make([
-                'costBasis' => FiatAmount::GBP('45'),
-                'sameDayQuantityAllocation' => new QuantityAllocation(),
-            ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given($sharePoolingAssetFiatCurrencySet, $someSharePoolingAssetsAcquired, $someSharePoolingAssetsDisposedOf)
-        ->when($acquireMoreSharePoolingAsset)
-        ->then($sharePoolingAssetDisposalReverted, $moreSharePoolingAssetAcquired, $correctedSharePoolingAssetsDisposedOf);
 });
 
 it('can acquire a share pooling asset several times within 30 days of their disposal', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
             sameDayQuantity: new Quantity('25'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
@@ -576,125 +442,91 @@ it('can acquire a share pooling asset several times within 30 days of their disp
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('75'),
             ]),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-25'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('25'),
             proceeds: FiatAmount::GBP('50'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
             thirtyDayQuantity: new Quantity('20'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposal1Reverted1 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
 
-    $sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
             ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired3->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('115')]),
-    );
+    ));
 
-    // When
-
-    $acquireSharePoolingAsset4 = new AcquireSharePoolingAsset(
+    when($acquireSharePoolingAsset4 = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('20'),
         costBasis: FiatAmount::GBP('40'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposal1Reverted2 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal,
-    );
-
-    $sharePoolingAssetDisposal2Reverted = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf2->disposal,
-    );
-
-    $sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
-        acquisition: new SharePoolingAssetAcquisition(
-            id: $acquireSharePoolingAsset4->transactionId,
-            date: $acquireSharePoolingAsset4->date,
-            quantity: $acquireSharePoolingAsset4->quantity,
-            costBasis: $acquireSharePoolingAsset4->costBasis,
-            thirtyDayQuantity: new Quantity('20'),
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal),
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2->disposal),
+        $sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireSharePoolingAsset4->transactionId,
+                date: $acquireSharePoolingAsset4->date,
+                quantity: $acquireSharePoolingAsset4->quantity,
+                costBasis: $acquireSharePoolingAsset4->costBasis,
+                thirtyDayQuantity: new Quantity('20'),
+            ),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->copyFrom($sharePoolingAssetDisposedOf1Corrected1->disposal)
+                ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('120')]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->copyFrom($sharePoolingAssetDisposedOf2->disposal)
+                ->withThirtyDayQuantity(new Quantity('15'), id: $sharePoolingAssetAcquired4->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('40')]),
         ),
     );
-
-    $sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->copyFrom($sharePoolingAssetDisposedOf1Corrected1->disposal)
-            ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('120')]),
-    );
-
-    $sharePoolingAssetDisposedOf2Corrected = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->copyFrom($sharePoolingAssetDisposedOf2->disposal)
-            ->withThirtyDayQuantity(new Quantity('15'), id: $sharePoolingAssetAcquired4->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('40')]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given(
-        $sharePoolingAssetFiatCurrencySet,
-        $sharePoolingAssetAcquired1,
-        $sharePoolingAssetAcquired2,
-        $sharePoolingAssetDisposedOf1,
-        $sharePoolingAssetDisposedOf2,
-        $sharePoolingAssetDisposal1Reverted1,
-        $sharePoolingAssetAcquired3,
-        $sharePoolingAssetDisposedOf1Corrected1,
-    )
-        ->when($acquireSharePoolingAsset4)
-        ->then(
-            $sharePoolingAssetDisposal1Reverted2,
-            $sharePoolingAssetDisposal2Reverted,
-            $sharePoolingAssetAcquired4,
-            $sharePoolingAssetDisposedOf1Corrected2,
-            $sharePoolingAssetDisposedOf2Corrected,
-        );
 });
 
 it('can dispose of a share pooling asset on the same day as an acquisition within 30 days of another disposal', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
             sameDayQuantity: new Quantity('25'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
@@ -702,164 +534,127 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('75'),
             ]),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->make([
                 'date' => LocalDate::parse('2015-10-25'),
                 'quantity' => new Quantity('25'),
                 'costBasis' => FiatAmount::GBP('25'),
             ]),
-    );
+    ));
 
-    $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
             thirtyDayQuantity: new Quantity('20'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposal1Reverted1 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
 
-    $sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
             ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired3->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('115')]),
-    );
+    ));
 
-    $sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-29'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('40'),
             thirtyDayQuantity: new Quantity('20'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposal1Reverted2 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
 
-    $sharePoolingAssetDisposal2Reverted1 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf2->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2->disposal));
 
-    $sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
-        disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal,
-    );
+    given(new SharePoolingAssetDisposedOf(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
 
-    $sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
+    given(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1Corrected1->disposal)
             ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('120')]),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf2Corrected1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf2Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf2->disposal)
             ->withThirtyDayQuantity(new Quantity('15'), id: $sharePoolingAssetAcquired4->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('40')]),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-29'),
         quantity: new Quantity('10'),
         proceeds: FiatAmount::GBP('30'),
+    ));
+
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2Corrected1->disposal),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOf2->disposal)
+                ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('30')]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired4->acquisition->id)
+                ->make([
+                    'id' => $disposeOfSharePoolingAsset3->transactionId,
+                    'date' => $disposeOfSharePoolingAsset3->date,
+                    'quantity' => $disposeOfSharePoolingAsset3->quantity,
+                    'costBasis' => FiatAmount::GBP('20'),
+                    'proceeds' => $disposeOfSharePoolingAsset3->proceeds,
+                    'thirtyDayQuantityAllocation' => new QuantityAllocation(),
+                ]),
+        ),
     );
-
-    // Then
-
-    $sharePoolingAssetDisposal2Reverted2 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf2Corrected1->disposal,
-    );
-
-    $sharePoolingAssetDisposedOf2Corrected2 = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->revert($sharePoolingAssetDisposedOf2->disposal)
-            ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('30')]),
-    );
-
-    $sharePoolingAssetDisposedOf3 = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired4->acquisition->id)
-            ->make([
-                'id' => $disposeOfSharePoolingAsset3->transactionId,
-                'date' => $disposeOfSharePoolingAsset3->date,
-                'quantity' => $disposeOfSharePoolingAsset3->quantity,
-                'costBasis' => FiatAmount::GBP('20'),
-                'proceeds' => $disposeOfSharePoolingAsset3->proceeds,
-                'thirtyDayQuantityAllocation' => new QuantityAllocation(),
-            ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given(
-        $sharePoolingAssetFiatCurrencySet,
-        $sharePoolingAssetAcquired1,
-        $sharePoolingAssetAcquired2,
-        $sharePoolingAssetDisposedOf1,
-        $sharePoolingAssetDisposedOf2,
-        $sharePoolingAssetDisposal1Reverted1,
-        $sharePoolingAssetAcquired3,
-        $sharePoolingAssetDisposedOf1Corrected1,
-        $sharePoolingAssetDisposal1Reverted2,
-        $sharePoolingAssetDisposal2Reverted1,
-        $sharePoolingAssetAcquired4,
-        $sharePoolingAssetDisposedOf1Corrected2,
-        $sharePoolingAssetDisposedOf2Corrected1,
-    )
-        ->when($disposeOfSharePoolingAsset3)
-        ->then($sharePoolingAssetDisposal2Reverted2, $sharePoolingAssetDisposedOf2Corrected2, $sharePoolingAssetDisposedOf3);
 });
 
 it('can acquire a same-day share pooling asset several times on the same day as their disposal', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
             proceeds: FiatAmount::GBP('75'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposalReverted = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf->disposal));
 
-    $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
             sameDayQuantity: new Quantity('20'), // $sharePoolingAssetDisposedOf
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOfCorrected = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOfCorrected = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->revert($sharePoolingAssetDisposedOf->disposal)
             ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
@@ -868,130 +663,102 @@ it('can acquire a same-day share pooling asset several times on the same day as 
                 'quantity' => new Quantity('50'),
                 'costBasis' => FiatAmount::GBP('55'),
             ]),
-    );
+    ));
 
-    // When
-
-    $acquireSharePoolingAsset3 = new AcquireSharePoolingAsset(
+    when($acquireSharePoolingAsset3 = new AcquireSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('10'),
         costBasis: FiatAmount::GBP('14'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposalReverted2 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOfCorrected->disposal,
-    );
-
-    $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
-        acquisition: new SharePoolingAssetAcquisition(
-            id: $acquireSharePoolingAsset3->transactionId,
-            date: $acquireSharePoolingAsset3->date,
-            quantity: $acquireSharePoolingAsset3->quantity,
-            costBasis: $acquireSharePoolingAsset3->costBasis,
-            sameDayQuantity: new Quantity('10'), // $sharePoolingAssetDisposedOf
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOfCorrected->disposal),
+        $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireSharePoolingAsset3->transactionId,
+                date: $acquireSharePoolingAsset3->date,
+                quantity: $acquireSharePoolingAsset3->quantity,
+                costBasis: $acquireSharePoolingAsset3->costBasis,
+                sameDayQuantity: new Quantity('10'), // $sharePoolingAssetDisposedOf
+            ),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOfCorrected->disposal)
+                ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+                ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired3->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('59')]),
         ),
     );
-
-    $sharePoolingAssetsDisposedOfCorrected2 = new SharePoolingAssetDisposedOf(
-        disposal: SharePoolingAssetDisposal::factory()
-            ->revert($sharePoolingAssetDisposedOfCorrected->disposal)
-            ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
-            ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired3->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('59')]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given(
-        $sharePoolingAssetFiatCurrencySet,
-        $sharePoolingAssetAcquired1,
-        $sharePoolingAssetDisposedOf,
-        $sharePoolingAssetDisposalReverted,
-        $sharePoolingAssetAcquired2,
-        $sharePoolingAssetDisposedOfCorrected,
-    )
-        ->when($acquireSharePoolingAsset3)
-        ->then($sharePoolingAssetDisposalReverted2, $sharePoolingAssetAcquired3, $sharePoolingAssetsDisposedOfCorrected2);
 });
 
 it('can dispose of a same-day share pooling asset several times on the same day as several acquisitions', function () {
-    // Given
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
-    $sharePoolingAssetFiatCurrencySet = new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP);
-
-    $sharePoolingAssetAcquired1 = new SharePoolingAssetAcquired(
+    given(new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-21'),
             quantity: new Quantity('100'),
             costBasis: FiatAmount::GBP('100'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('50'),
             costBasis: FiatAmount::GBP('50'),
             proceeds: FiatAmount::GBP('75'),
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposalReverted1 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
 
-    $sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
             sameDayQuantity: new Quantity('20'), // $sharePoolingAssetDisposedOf1
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
+    given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
             ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('55')]),
-    );
+    ));
 
-    $sharePoolingAssetDisposalReverted2 = new SharePoolingAssetDisposalReverted(
-        disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal,
-    );
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
 
-    $sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
+    given($sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-22'),
             quantity: new Quantity('60'),
             costBasis: FiatAmount::GBP('90'),
             sameDayQuantity: new Quantity('30'), // $sharePoolingAssetDisposedOf1
         ),
-    );
+    ));
 
-    $sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
+    given(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1Corrected1->disposal)
             ->withSameDayQuantity(new Quantity('30'), id: $sharePoolingAssetAcquired3->acquisition->id)
             ->make(['costBasis' => FiatAmount::GBP('71.875')]),
-    );
+    ));
 
-    // When
-
-    $disposeOfSharePoolingAsset2 = new DisposeOfSharePoolingAsset(
+    when($disposeOfSharePoolingAsset2 = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
         date: LocalDate::parse('2015-10-22'),
         quantity: new Quantity('40'),
         proceeds: FiatAmount::GBP('50'),
-    );
+    ));
 
-    // Then
-
-    $sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
+    then(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->withSameDayQuantity(new Quantity('30'), id: $sharePoolingAssetAcquired3->acquisition->id)
             ->make([
@@ -1001,20 +768,5 @@ it('can dispose of a same-day share pooling asset several times on the same day 
                 'costBasis' => FiatAmount::GBP('53.125'),
                 'proceeds' => $disposeOfSharePoolingAsset2->proceeds,
             ]),
-    );
-
-    /** @var AggregateRootTestCase $this */
-    $this->given(
-        $sharePoolingAssetFiatCurrencySet,
-        $sharePoolingAssetAcquired1,
-        $sharePoolingAssetDisposedOf1,
-        $sharePoolingAssetDisposalReverted1,
-        $sharePoolingAssetAcquired2,
-        $sharePoolingAssetDisposedOf1Corrected1,
-        $sharePoolingAssetDisposalReverted2,
-        $sharePoolingAssetAcquired3,
-        $sharePoolingAssetDisposedOf1Corrected2,
-    )
-        ->when($disposeOfSharePoolingAsset2)
-        ->then($sharePoolingAssetDisposedOf2);
+    ));
 });


### PR DESCRIPTION
## Summary

This PR introduces the use of EventSauce's [Pest utilities](https://github.com/EventSaucePHP/PestUtilities) instead of the regular [test utilities](https://github.com/EventSaucePHP/TestUtilities).

## Explanation

This simplifies the syntax of aggregate tests.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
