### PR TITLE
Review command

### DIFF
--- a/app/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
+++ b/app/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
@@ -13,6 +13,17 @@ use Domain\ValueObjects\FiatAmount;
 
 final class TaxYearSummaryRepository implements TaxYearSummaryRepositoryInterface
 {
+    public function find(TaxYearId $taxYearId): ?TaxYearSummary
+    {
+        return TaxYearSummary::find($taxYearId->toString());
+    }
+
+    /** @return list<TaxYearSummary> */
+    public function all(): array
+    {
+        return TaxYearSummary::all()->all();
+    }
+
     public function updateCapitalGain(TaxYearId $taxYearId, CapitalGain $capitalGain): void
     {
         $this->fetchTaxYearSummary($taxYearId, $capitalGain->currency())

--- a/app/Commands/Command.php
+++ b/app/Commands/Command.php
@@ -2,18 +2,18 @@
 
 namespace App\Commands;
 
-use App\Services\Presenter\Presenter;
+use App\Services\Presenter\PresenterContract;
 use LaravelZero\Framework\Commands\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command extends BaseCommand
 {
-    protected Presenter $presenter;
+    protected PresenterContract $presenter;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->presenter = new Presenter($input, $output);
+        $this->presenter = resolve(PresenterContract::class, [$input, $output]); // @phpstan-ignore-line
 
         return parent::execute($input, $output);
     }

--- a/app/Commands/Process.php
+++ b/app/Commands/Process.php
@@ -69,6 +69,6 @@ final class Process extends Command
 
         $this->presenter->success('Transactions successfully processed!');
 
-        return self::SUCCESS;
+        return $this->option('test') ? self::SUCCESS : $this->call('review');
     }
 }

--- a/app/Commands/Review.php
+++ b/app/Commands/Review.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Commands;
+
+use Domain\Aggregates\TaxYear\Projections\TaxYearSummary;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearSummaryRepository;
+use Domain\Aggregates\TaxYear\ValueObjects\Exceptions\TaxYearIdException;
+use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
+
+final class Review extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'review
+        {taxyear? : The tax year whose summary to display (e.g. 2015-2016)}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Display a tax year\'s summary';
+
+    /** Execute the console command. */
+    public function handle(TaxYearSummaryRepository $repository): int
+    {
+        $taxYear = $this->argument('taxyear');
+
+        if (! is_null($taxYear) && ! is_string($taxYear)) {
+            $this->presenter->error(TaxYearIdException::invalidTaxYear()->getMessage());
+
+            return self::INVALID;
+        }
+
+        $availableTaxYears = array_filter(array_map(
+            fn (mixed $taxYearId) => $taxYearId instanceof TaxYearId ? $taxYearId->toString() : null,
+            array_column($repository->all(), 'tax_year_id'),
+        ));
+
+        if (empty($availableTaxYears)) {
+            $this->presenter->warning('No tax year to review. Please submit transactions first, using the `process` command');
+
+            return self::SUCCESS;
+        }
+
+        // Order tax years from more recent to older
+        rsort($availableTaxYears);
+
+        $taxYear ??= count($availableTaxYears) === 1
+            ? $availableTaxYears[0]
+            : $this->presenter->choice('Please select a tax year', $availableTaxYears, $availableTaxYears[0]);
+
+        return $this->summary($repository, $taxYear, $availableTaxYears);
+    }
+
+    /** @param list<string> $availableTaxYears */
+    private function summary(TaxYearSummaryRepository $repository, string $taxYear, array $availableTaxYears): int
+    {
+        try {
+            $taxYearId = TaxYearId::fromString($taxYear);
+        } catch (TaxYearIdException $exception) {
+            $this->presenter->error($exception->getMessage());
+
+            return self::INVALID;
+        }
+
+        $taxYearSummary = $repository->find($taxYearId);
+
+        assert($taxYearSummary instanceof TaxYearSummary);
+
+        $this->presenter->summary(
+            taxYear: $taxYear,
+            proceeds: (string) $taxYearSummary->capital_gain->proceeds,
+            costBasis: (string) $taxYearSummary->capital_gain->costBasis,
+            nonAttributableAllowableCost: (string) $taxYearSummary->non_attributable_allowable_cost,
+            totalCostBasis: (string) $taxYearSummary->capital_gain->costBasis->plus($taxYearSummary->non_attributable_allowable_cost),
+            capitalGain: (string) $taxYearSummary->capital_gain->difference->minus($taxYearSummary->non_attributable_allowable_cost),
+            income: (string) $taxYearSummary->income,
+        );
+
+        // If there is only one tax year available, we are done
+        if (count($availableTaxYears) === 1) {
+            return self::SUCCESS;
+        }
+
+        $taxYear = $this->presenter->choice('Review another tax year?', array_merge(['No'], $availableTaxYears), 'No');
+
+        if ($taxYear === 'No') {
+            return self::SUCCESS;
+        }
+
+        return $this->summary($repository, $taxYear, $availableTaxYears);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Services\ActionRunner\ActionRunner;
+use App\Services\Presenter\Presenter;
+use App\Services\Presenter\PresenterContract;
 use App\Services\TransactionProcessor\TransactionProcessor;
 use App\Services\TransactionProcessor\TransactionProcessorContract;
 use App\Services\TransactionReader\Adapters\PhpSpreadsheetAdapter;
@@ -23,6 +25,7 @@ final class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(ActionRunnerInterface::class, fn (Application $app) => new ActionRunner());
+        $this->app->singleton(PresenterContract::class, fn (Application $app, array $params) => new Presenter($params[0], $params[1]));
         $this->app->singleton(TransactionDispatcherContract::class, fn (Application $app) => resolve(TransactionDispatcher::class));
         $this->app->singleton(TransactionProcessorContract::class, fn (Application $app) => resolve(TransactionProcessor::class));
         $this->app->singleton(TransactionReader::class, fn (Application $app) => new PhpSpreadsheetAdapter());

--- a/app/Services/Presenter/Presenter.php
+++ b/app/Services/Presenter/Presenter.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class Presenter
+final class Presenter implements PresenterContract
 {
     private SymfonyStyle $ui;
 
@@ -15,22 +15,62 @@ final class Presenter
         $this->ui = new SymfonyStyle($input, $output);
     }
 
-    /** Display a success message. */
+    /** Display an error message. */
+    public function error(string $message): void
+    {
+        $this->ui->block(sprintf(' 🚨  %s', $message), null, 'fg=white;bg=red', ' ', true);
+    }
+
+    /** Display an information message. */
     public function info(string $message): void
     {
         $this->ui->block(sprintf(' ℹ️   %s', $message), null, 'fg=white;bg=blue', ' ', true);
     }
 
     /** Display a success message. */
-    public function error(string $message): void
-    {
-        $this->ui->block(sprintf(' 🚨  %s', $message), null, 'fg=white;bg=red', ' ', true);
-    }
-
-    /** Display a success message. */
     public function success(string $message): void
     {
         $this->ui->block(sprintf(' 🎉  %s', $message), null, 'fg=white;bg=green', ' ', true);
+    }
+
+    /** Display a warning message. */
+    public function warning(string $message): void
+    {
+        $this->ui->block(sprintf(' ⚠️   %s', $message), null, 'fg=yellow;bg=default', ' ', true);
+    }
+
+    /**
+     * Display multiple choices.
+     *
+     * @param list<string> $choices
+     *
+     * @codeCoverageIgnore
+     */
+    public function choice(string $question, array $choices, ?string $default = null): string
+    {
+        $choice = $this->ui->choice($question, $choices, $default);
+
+        assert(is_string($choice));
+
+        return $choice;
+    }
+
+    /** Display a tax year's summary. */
+    public function summary(
+        string $taxYear,
+        string $proceeds,
+        string $costBasis,
+        string $nonAttributableAllowableCost,
+        string $totalCostBasis,
+        string $capitalGain,
+        string $income,
+    ): void {
+        $this->info(sprintf('Summary for tax year %s', $taxYear));
+
+        $this->ui->table(
+            ['Proceeds', 'Cost basis', 'Non-attributable allowable cost', 'Total cost basis', 'Capital gain or loss', 'Income'],
+            [[$proceeds, $costBasis, $nonAttributableAllowableCost, $totalCostBasis, $capitalGain, $income]],
+        );
     }
 
     /** Initiate a progress bar. */

--- a/app/Services/Presenter/PresenterContract.php
+++ b/app/Services/Presenter/PresenterContract.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Presenter;
+
+interface PresenterContract
+{
+    /** Display an error message. */
+    public function error(string $message): void;
+
+    /** Display an information message. */
+    public function info(string $message): void;
+
+    /** Display a success message. */
+    public function success(string $message): void;
+
+    /** Display a warning message. */
+    public function warning(string $message): void;
+
+    /**
+     * Display multiple choices.
+     *
+     * @param list<string> $choices
+     */
+    public function choice(string $question, array $choices, ?string $default = null): string;
+
+    /** Display a tax year's summary. */
+    public function summary(
+        string $taxYear,
+        string $proceeds,
+        string $costBasis,
+        string $nonAttributableAllowableCost,
+        string $totalCostBasis,
+        string $capitalGain,
+        string $income
+    ): void;
+
+    /** Initiate a progress bar. */
+    public function progressStart(int $size): void;
+
+    /** Advance a progress bar. */
+    public function progressAdvance(int $step = 1): void;
+
+    /** Complete a progress bar. */
+    public function progressComplete(): void;
+}

--- a/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
+++ b/domain/src/Aggregates/TaxYear/Projections/TaxYearSummary.php
@@ -20,7 +20,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property FiatAmount   $non_attributable_allowable_cost
  * @property TaxYearId    $tax_year_id
  *
- * @method static self firstOrNew($attributes = [], $values = [])
+ * @method static self|null find(string $id)
+ * @method static self      firstOrNew($attributes = [], $values = [])
  */
 final class TaxYearSummary extends Model
 {

--- a/domain/src/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
+++ b/domain/src/Aggregates/TaxYear/Repositories/TaxYearSummaryRepository.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Domain\Aggregates\TaxYear\Repositories;
 
+use Domain\Aggregates\TaxYear\Projections\TaxYearSummary;
 use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
 use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
 use Domain\ValueObjects\FiatAmount;
 
 interface TaxYearSummaryRepository
 {
+    public function find(TaxYearId $taxYearId): ?TaxYearSummary;
+
+    /** @return list<TaxYearSummary> */
+    public function all(): array;
+
     public function updateCapitalGain(TaxYearId $taxYearId, CapitalGain $capitalGain): void;
 
     public function updateIncome(TaxYearId $taxYearId, FiatAmount $income): void;

--- a/domain/src/Aggregates/TaxYear/ValueObjects/Exceptions/TaxYearIdException.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/Exceptions/TaxYearIdException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Aggregates\TaxYear\ValueObjects\Exceptions;
+
+use RuntimeException;
+
+final class TaxYearIdException extends RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function invalidTaxYear(): self
+    {
+        return new self('Tax years must be two consecutive years separated by an hyphen (e.g. "2021-2022")');
+    }
+}

--- a/domain/src/Aggregates/TaxYear/ValueObjects/TaxYearId.php
+++ b/domain/src/Aggregates/TaxYear/ValueObjects/TaxYearId.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Domain\Aggregates\TaxYear\ValueObjects;
 
 use Brick\DateTime\LocalDate;
+use Domain\Aggregates\TaxYear\ValueObjects\Exceptions\TaxYearIdException;
 use Domain\ValueObjects\AggregateRootId;
 
 final readonly class TaxYearId extends AggregateRootId
@@ -22,5 +23,16 @@ final readonly class TaxYearId extends AggregateRootId
         }
 
         return self::fromString(sprintf('%s-%s', $year, $year + 1));
+    }
+
+    public static function fromString(string $aggregateRootId): static
+    {
+        $years = explode('-', $aggregateRootId);
+
+        if (count($years) !== 2 || (int) $years[1] !== (int) $years[0] + 1) {
+            throw TaxYearIdException::invalidTaxYear();
+        }
+
+        return parent::fromString($aggregateRootId);
     }
 }

--- a/domain/src/ValueObjects/FiatAmount.php
+++ b/domain/src/ValueObjects/FiatAmount.php
@@ -126,6 +126,6 @@ final readonly class FiatAmount implements Stringable
 
     public function __toString(): string
     {
-        return sprintf('%s%s', $this->currency->symbol(), $this->quantity);
+        return sprintf('%s%s', $this->currency->symbol(), number_format((float) $this->quantity->quantity, 2));
     }
 }

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
@@ -176,5 +176,5 @@ it('can return an acquisition as a string', function () {
         'costBasis' => FiatAmount::GBP('100'),
     ]);
 
-    expect((string) $acquisition)->toBe('2015-10-21: acquired 100 tokens for £100');
+    expect((string) $acquisition)->toBe('2015-10-21: acquired 100 tokens for £100.00');
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalTest.php
@@ -129,5 +129,5 @@ it('can return a disposal as a string', function () {
         'costBasis' => FiatAmount::GBP('100'),
     ]);
 
-    expect((string) $acquisition)->toBe('2015-10-21: disposed of 100 tokens for £150 (cost basis: £100)');
+    expect((string) $acquisition)->toBe('2015-10-21: disposed of 100 tokens for £150.00 (cost basis: £100.00)');
 });

--- a/domain/tests/Aggregates/TaxYear/ValueObjects/TaxYearIdTest.php
+++ b/domain/tests/Aggregates/TaxYear/ValueObjects/TaxYearIdTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Brick\DateTime\LocalDate;
+use Domain\Aggregates\TaxYear\ValueObjects\Exceptions\TaxYearIdException;
 use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
 
 it('can create an aggregate root ID from a date', function (string $date, string $taxYear) {
@@ -10,3 +11,8 @@ it('can create an aggregate root ID from a date', function (string $date, string
     ['2016-04-05', '2015-2016'],
     ['2016-04-06', '2016-2017'],
 ]);
+
+it('cannot create an aggregate root ID because the value is invalid', function () {
+    expect(fn () => TaxYearId::fromString('foo'))
+        ->toThrow(TaxYearIdException::class, TaxYearIdException::invalidTaxYear()->getMessage());
+});

--- a/domain/tests/ValueObjects/FeeTest.php
+++ b/domain/tests/ValueObjects/FeeTest.php
@@ -14,5 +14,5 @@ it('can tell whether the fee is fiat', function () {
 it('can return the fee as a string', function () {
     $fee = new Fee(new Asset(FiatCurrency::GBP->value), new Quantity('100'), FiatAmount::GBP('100'));
 
-    expect((string) $fee)->toBe('GBP 100 (market value: £100)');
+    expect((string) $fee)->toBe('GBP 100 (market value: £100.00)');
 });

--- a/domain/tests/ValueObjects/FiatAmountTest.php
+++ b/domain/tests/ValueObjects/FiatAmountTest.php
@@ -181,6 +181,9 @@ it('cannot perform a fiat amount operation because the currencies do not match',
     'dividedBy',
 ]);
 
-it('can express a fiat amount as a string', function () {
-    expect((string) FiatAmount::GBP('10'))->toBe('£10');
-});
+it('can express a fiat amount as a string', function (string $quantity, string $result) {
+    expect((string) FiatAmount::GBP($quantity))->toBe($result);
+})->with([
+    'scenario 1' => ['10', '£10.00'],
+    'scenario 2' => ['10000.10', '£10,000.10'],
+]);

--- a/domain/tests/ValueObjects/Transactions/TransferTest.php
+++ b/domain/tests/ValueObjects/Transactions/TransferTest.php
@@ -33,5 +33,5 @@ it('can return the transfer as a string', function () {
         'fee' => new Fee(new Asset(FiatCurrency::GBP->value), new Quantity('1'), FiatAmount::GBP('1')),
     ]);
 
-    expect((string) $transaction)->toBe('2015-10-21 | transferred: FOO | non-fungible asset: no | quantity: 100 | Fee: GBP 1 (market value: £1)');
+    expect((string) $transaction)->toBe('2015-10-21 | transferred: FOO | non-fungible asset: no | quantity: 100 | Fee: GBP 1 (market value: £1.00)');
 });

--- a/tests/Feature/Commands/ReviewTest.php
+++ b/tests/Feature/Commands/ReviewTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Domain\Aggregates\TaxYear\Projections\TaxYearSummary;
+use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
+use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use LaravelZero\Framework\Commands\Command;
+
+it('can review a tax year', function () {
+    TaxYearSummary::factory()->create([
+        'tax_year_id' => TaxYearId::fromString('2015-2016'),
+        'currency' => FiatCurrency::GBP,
+        'capital_gain' => new CapitalGain(
+            costBasis: FiatAmount::GBP('100'),
+            proceeds: FiatAmount::GBP('200'),
+        ),
+        'income' => FiatAmount::GBP('50'),
+        'non_attributable_allowable_cost' => FiatAmount::GBP('75'),
+    ]);
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->artisan('review')
+        ->expectsOutputToContain('---------- ------------ --------------------------------- ------------------ ---------------------- --------')
+        ->expectsOutputToContain(' Proceeds   Cost basis   Non-attributable allowable cost   Total cost basis   Capital gain or loss   Income ')
+        ->expectsOutputToContain(' £200.00    £100.00      £75.00                            £175.00            £25.00                 £50.00 ')
+        ->assertExitCode(Command::SUCCESS);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,11 @@ use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function instance($abstract, $instance)
+    {
+        $this->app->bind($abstract, fn () => $instance);
+
+        return $instance;
+    }
 }

--- a/tests/Unit/Commands/ProcessTest.php
+++ b/tests/Unit/Commands/ProcessTest.php
@@ -22,13 +22,13 @@ function generator(array $value): Generator
     yield $value;
 }
 
-it('cannot read a spreadsheet because the file is not found', function () {
+it('cannot process a spreadsheet because the file is not found', function () {
     $this->artisan('process', ['spreadsheet' => 'foo'])
         ->expectsOutputToContain('No spreadsheet could be found at foo')
         ->assertExitCode(Command::INVALID);
 });
 
-it('cannot read a spreadsheet because of a transaction reader exception', function () {
+it('cannot process a spreadsheet because of a transaction reader exception', function () {
     $exception = TransactionReaderException::missingHeaders(['foo']);
 
     $this->transactionReader->shouldReceive('read')->with($this->path)->once()->andThrow($exception);
@@ -38,7 +38,7 @@ it('cannot read a spreadsheet because of a transaction reader exception', functi
         ->assertExitCode(Command::INVALID);
 });
 
-it('cannot read a spreadsheet because of a transaction processor exception', function () {
+it('cannot process a spreadsheet because of a transaction processor exception', function () {
     $exception = TransactionProcessorException::cannotParseDate('foo');
 
     $this->transactionReader->shouldReceive('read')->with($this->path)->once()->andReturn(generator(['foo']));
@@ -50,7 +50,7 @@ it('cannot read a spreadsheet because of a transaction processor exception', fun
         ->assertExitCode(Command::INVALID);
 });
 
-it('can read a spreadsheet and pass the transactions to the transaction processor', function () {
+it('can process a spreadsheet and pass the transactions to the transaction processor', function () {
     $this->transactionReader->shouldReceive('read')->with($this->path)->once()->andReturn(generator(['foo']));
     $this->transactionReader->shouldReceive('read')->with($this->path)->once()->andReturn(generator(['foo']));
 

--- a/tests/Unit/Commands/ReviewTest.php
+++ b/tests/Unit/Commands/ReviewTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Services\Presenter\PresenterContract;
+use Domain\Aggregates\TaxYear\Projections\TaxYearSummary;
+use Domain\Aggregates\TaxYear\Repositories\TaxYearSummaryRepository;
+use Domain\Aggregates\TaxYear\ValueObjects\CapitalGain;
+use Domain\Aggregates\TaxYear\ValueObjects\TaxYearId;
+use Domain\Enums\FiatCurrency;
+use Domain\ValueObjects\FiatAmount;
+use LaravelZero\Framework\Commands\Command;
+
+beforeEach(function () {
+    $this->taxYearSummaryRepository = Mockery::mock(TaxYearSummaryRepository::class);
+
+    $this->instance(TaxYearSummaryRepository::class, $this->taxYearSummaryRepository);
+});
+
+it('cannot review a tax year because the submitted tax year is invalid', function (mixed $value) {
+    $this->taxYearSummaryRepository->shouldReceive('all')->andReturn([['tax_year_id' => TaxYearId::fromString('2021-2022')]]);
+
+    $this->artisan('review', ['taxyear' => $value])
+        ->expectsOutputToContain('Tax years must be two consecutive years separated by an hyphen')
+        ->assertExitCode(Command::INVALID);
+})->with(['foo', true]);
+
+it('cannot review a tax year because none are available', function () {
+    $this->taxYearSummaryRepository->shouldReceive('all')->once()->andReturn([]);
+
+    $this->artisan('review')
+        ->expectsOutputToContain('No tax year to review')
+        ->assertExitCode(Command::SUCCESS);
+});
+
+it('can review a tax year', function () {
+    $taxYearId = TaxYearId::fromString('2021-2022');
+
+    $this->taxYearSummaryRepository->shouldReceive('all')->once()->andReturn([['tax_year_id' => $taxYearId]]);
+    $this->taxYearSummaryRepository->shouldReceive('find')
+        ->once()
+        ->withArgs(fn (TaxYearId $id) => $id->toString() === $taxYearId->toString())
+        ->andReturn(TaxYearSummary::factory()->make([
+            'tax_year_id' => $taxYearId,
+            'currency' => FiatCurrency::GBP,
+            'capital_gain' => new CapitalGain(
+                costBasis: FiatAmount::GBP('2'),
+                proceeds: FiatAmount::GBP('4'),
+            ),
+            'income' => FiatAmount::GBP('10'),
+            'non_attributable_allowable_cost' => FiatAmount::GBP('1'),
+        ]));
+
+    $presenter = Mockery::mock(PresenterContract::class);
+    $presenter->shouldReceive('summary')
+        ->once()
+        ->with($taxYearId->toString(), '£4.00', '£2.00', '£1.00', '£3.00', '£1.00', '£10.00')
+        ->andReturn();
+
+    $this->instance(PresenterContract::class, $presenter);
+
+    $this->artisan('review')->assertExitCode(Command::SUCCESS);
+});
+
+it('offers to choose a tax year', function () {
+    $this->taxYearSummaryRepository->shouldReceive('all')->once()->andReturn([
+        ['tax_year_id' => TaxYearId::fromString('2021-2022')],
+        ['tax_year_id' => TaxYearId::fromString('2022-2023')],
+    ]);
+
+    $this->taxYearSummaryRepository->shouldReceive('find')
+        ->once()
+        ->withArgs(fn (TaxYearId $id) => $id->toString() === '2022-2023')
+        ->andReturn(TaxYearSummary::factory()->make());
+
+    $this->taxYearSummaryRepository->shouldReceive('find')
+        ->once()
+        ->withArgs(fn (TaxYearId $id) => $id->toString() === '2021-2022')
+        ->andReturn(TaxYearSummary::factory()->make());
+
+    $presenter = Mockery::mock(PresenterContract::class);
+    $presenter->shouldReceive('choice')->once()->with('Please select a tax year', ['2022-2023', '2021-2022'], '2022-2023')->andReturn('2022-2023');
+    $presenter->shouldReceive('choice')->once()->with('Review another tax year?', ['No', '2022-2023', '2021-2022'], 'No')->andReturn('2021-2022');
+    $presenter->shouldReceive('choice')->once()->with('Review another tax year?', ['No', '2022-2023', '2021-2022'], 'No')->andReturn('No');
+    $presenter->shouldReceive('summary')->twice()->andReturn();
+
+    $this->instance(PresenterContract::class, $presenter);
+
+    $this->artisan('review')->assertExitCode(Command::SUCCESS);
+});


### PR DESCRIPTION
## Summary

This PR introduces the `Review` command to display tax year summaries in the terminal.

## Explanation

The new command is automatically called at the end of the `Process` command. It can also be called independently and will then read the data already present in the database:

```bash
$ dime review
$ dime review 2015-2016
```

If no tax year is specified, the command will prompt the user to choose among the available tax years, or directly display the data if there's only one available. It will prompt the user to call the `proceed` command if the table is empty.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
