### PR TITLE
Invokable actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Validate tag
-        uses: FidelusAleksander/gh-action-regex@v0.2.0
+        uses: FidelusAleksander/gh-action-regex@v0.3.0
         with:
           regex_pattern: "^v\\d+(\\.\\d+)?(\\.\\d+)?$"
           regex_match_type: match

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAsset.php
@@ -22,7 +22,7 @@ final readonly class AcquireNonFungibleAsset implements Stringable, WithAsset
     ) {
     }
 
-    public function handle(NonFungibleAssetRepository $nonFungibleAssetRepository, ActionRunner $runner): void
+    public function __invoke(NonFungibleAssetRepository $nonFungibleAssetRepository, ActionRunner $runner): void
     {
         $nonFungibleAssetId = NonFungibleAssetId::fromAsset($this->asset);
         $nonFungibleAsset = $nonFungibleAssetRepository->get($nonFungibleAssetId);

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAsset.php
@@ -22,7 +22,7 @@ final readonly class DisposeOfNonFungibleAsset implements Stringable, Timely, Wi
     ) {
     }
 
-    public function handle(NonFungibleAssetRepository $nonFungibleAssetRepository): void
+    public function __invoke(NonFungibleAssetRepository $nonFungibleAssetRepository): void
     {
         $nonFungibleAssetId = NonFungibleAssetId::fromAsset($this->asset);
         $nonFungibleAsset = $nonFungibleAssetRepository->get($nonFungibleAssetId);

--- a/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
+++ b/domain/src/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasis.php
@@ -22,7 +22,7 @@ final readonly class IncreaseNonFungibleAssetCostBasis implements Stringable, Ti
     ) {
     }
 
-    public function handle(NonFungibleAssetRepository $nonFungibleAssetRepository): void
+    public function __invoke(NonFungibleAssetRepository $nonFungibleAssetRepository): void
     {
         $nonFungibleAssetId = NonFungibleAssetId::fromAsset($this->asset);
         $nonFungibleAsset = $nonFungibleAssetRepository->get($nonFungibleAssetId);

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAsset.php
@@ -27,7 +27,7 @@ final readonly class AcquireSharePoolingAsset implements Stringable, Timely, Wit
     ) {
     }
 
-    public function handle(SharePoolingAssetRepository $sharePoolingAssetRepository): void
+    public function __invoke(SharePoolingAssetRepository $sharePoolingAssetRepository): void
     {
         $sharePoolingAssetId = SharePoolingAssetId::fromAsset($this->asset);
         $sharePoolingAsset = $sharePoolingAssetRepository->get($sharePoolingAssetId);

--- a/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAsset.php
@@ -27,7 +27,7 @@ final readonly class DisposeOfSharePoolingAsset implements Stringable, Timely, W
     ) {
     }
 
-    public function handle(SharePoolingAssetRepository $sharePoolingAssetRepository): void
+    public function __invoke(SharePoolingAssetRepository $sharePoolingAssetRepository): void
     {
         $sharePoolingAssetId = SharePoolingAssetId::fromAsset($this->asset);
         $sharePoolingAsset = $sharePoolingAssetRepository->get($sharePoolingAssetId);

--- a/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
+++ b/domain/src/Aggregates/TaxYear/Actions/RevertCapitalGainUpdate.php
@@ -18,7 +18,7 @@ final class RevertCapitalGainUpdate implements Stringable
     ) {
     }
 
-    public function handle(TaxYearRepository $taxYearRepository): void
+    public function __invoke(TaxYearRepository $taxYearRepository): void
     {
         $taxYearId = TaxYearId::fromDate($this->date);
         $taxYear = $taxYearRepository->get($taxYearId);

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateCapitalGain.php
@@ -18,7 +18,7 @@ final class UpdateCapitalGain implements Stringable
     ) {
     }
 
-    public function handle(TaxYearRepository $taxYearRepository): void
+    public function __invoke(TaxYearRepository $taxYearRepository): void
     {
         $taxYearId = TaxYearId::fromDate($this->date);
         $taxYear = $taxYearRepository->get($taxYearId);

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateIncome.php
@@ -18,7 +18,7 @@ final class UpdateIncome implements Stringable
     ) {
     }
 
-    public function handle(TaxYearRepository $taxYearRepository): void
+    public function __invoke(TaxYearRepository $taxYearRepository): void
     {
         $taxYearId = TaxYearId::fromDate($this->date);
         $taxYear = $taxYearRepository->get($taxYearId);

--- a/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
+++ b/domain/src/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCost.php
@@ -18,7 +18,7 @@ final class UpdateNonAttributableAllowableCost implements Stringable
     ) {
     }
 
-    public function handle(TaxYearRepository $taxYearRepository): void
+    public function __invoke(TaxYearRepository $taxYearRepository): void
     {
         $taxYearId = TaxYearId::fromDate($this->date);
         $taxYear = $taxYearRepository->get($taxYearId);

--- a/domain/tests/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Actions/AcquireNonFungibleAssetTest.php
@@ -23,7 +23,7 @@ it('can acquire a non-fungible asset', function () {
     $nonFungibleAssetRepository->shouldReceive('get')->once()->andReturn($nonFungibleAsset);
     $nonFungibleAssetRepository->shouldReceive('save')->once()->with($nonFungibleAsset);
 
-    $acquireNonFungibleAsset->handle($nonFungibleAssetRepository, $runner);
+    $acquireNonFungibleAsset($nonFungibleAssetRepository, $runner);
 
     $nonFungibleAsset->shouldHaveReceived('acquire')->once()->with($acquireNonFungibleAsset);
 });
@@ -50,5 +50,5 @@ it('can increase the cost basis of a non-fungible asset', function () {
         ->withArgs(fn (IncreaseNonFungibleAssetCostBasis $action) => $action->date === $acquireNonFungibleAsset->date
             && $action->costBasisIncrease === $acquireNonFungibleAsset->costBasis);
 
-    $acquireNonFungibleAsset->handle($nonFungibleAssetRepository, $runner);
+    $acquireNonFungibleAsset($nonFungibleAssetRepository, $runner);
 });

--- a/domain/tests/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAssetTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Actions/DisposeOfNonFungibleAssetTest.php
@@ -20,7 +20,7 @@ it('can dispose of a non-fungible asset', function () {
     $nonFungibleAssetRepository->shouldReceive('get')->once()->andReturn($nonFungibleAsset);
     $nonFungibleAssetRepository->shouldReceive('save')->once()->with($nonFungibleAsset);
 
-    $disposeOfNonFungibleAsset->handle($nonFungibleAssetRepository);
+    $disposeOfNonFungibleAsset($nonFungibleAssetRepository);
 
     $nonFungibleAsset->shouldHaveReceived('disposeOf')->once()->with($disposeOfNonFungibleAsset);
 });

--- a/domain/tests/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasisTest.php
+++ b/domain/tests/Aggregates/NonFungibleAsset/Actions/IncreaseNonFungibleAssetCostBasisTest.php
@@ -20,7 +20,7 @@ it('can increase the cost basis of a non-fungible asset', function () {
     $nonFungibleAssetRepository->shouldReceive('get')->once()->andReturn($nonFungibleAsset);
     $nonFungibleAssetRepository->shouldReceive('save')->once()->with($nonFungibleAsset);
 
-    $increaseNonFungibleAssetCostBasis->handle($nonFungibleAssetRepository);
+    $increaseNonFungibleAssetCostBasis($nonFungibleAssetRepository);
 
     $nonFungibleAsset->shouldHaveReceived('increaseCostBasis')->once()->with($increaseNonFungibleAssetCostBasis);
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Actions/AcquireSharePoolingAssetTest.php
@@ -22,7 +22,7 @@ it('can acquire a share pooling asset', function () {
     $sharePoolingAssetRepository->shouldReceive('get')->once()->andReturn($sharePoolingAsset);
     $sharePoolingAssetRepository->shouldReceive('save')->once()->with($sharePoolingAsset);
 
-    $acquireSharePoolingAsset->handle($sharePoolingAssetRepository);
+    $acquireSharePoolingAsset($sharePoolingAssetRepository);
 
     $sharePoolingAsset->shouldHaveReceived('acquire')->once()->with($acquireSharePoolingAsset);
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Actions/DisposeOfSharePoolingAssetTest.php
@@ -22,7 +22,7 @@ it('can dispose of a share pooling asset', function () {
     $sharePoolingAssetRepository->shouldReceive('get')->once()->andReturn($sharePoolingAsset);
     $sharePoolingAssetRepository->shouldReceive('save')->once()->with($sharePoolingAsset);
 
-    $disposeOfSharePoolingAsset->handle($sharePoolingAssetRepository);
+    $disposeOfSharePoolingAsset($sharePoolingAssetRepository);
 
     $sharePoolingAsset->shouldHaveReceived('disposeOf')->once()->with($disposeOfSharePoolingAsset);
 });

--- a/domain/tests/Aggregates/TaxYear/Actions/RevertCapitalGainUpdateTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/RevertCapitalGainUpdateTest.php
@@ -22,7 +22,7 @@ it('can revert a capital gain update', function () {
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);
     $taxYearRepository->shouldReceive('save')->once()->with($taxYear);
 
-    $revertCapitalGainUpdate->handle($taxYearRepository);
+    $revertCapitalGainUpdate($taxYearRepository);
 
     $taxYear->shouldHaveReceived('revertCapitalGainUpdate')->once()->with($revertCapitalGainUpdate);
 });

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateCapitalGainTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateCapitalGainTest.php
@@ -22,7 +22,7 @@ it('can update the capital gain', function () {
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);
     $taxYearRepository->shouldReceive('save')->once()->with($taxYear);
 
-    $updateCapitalGain->handle($taxYearRepository);
+    $updateCapitalGain($taxYearRepository);
 
     $taxYear->shouldHaveReceived('updateCapitalGain')->once()->with($updateCapitalGain);
 });

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateIncomeTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateIncomeTest.php
@@ -18,7 +18,7 @@ it('can update the income', function () {
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);
     $taxYearRepository->shouldReceive('save')->once()->with($taxYear);
 
-    $updateIncome->handle($taxYearRepository);
+    $updateIncome($taxYearRepository);
 
     $taxYear->shouldHaveReceived('updateIncome')->once()->with($updateIncome);
 });

--- a/domain/tests/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCostTest.php
+++ b/domain/tests/Aggregates/TaxYear/Actions/UpdateNonAttributableAllowableCostTest.php
@@ -18,7 +18,7 @@ it('can update the non-attributable allowable cost', function () {
     $taxYearRepository->shouldReceive('get')->once()->andReturn($taxYear);
     $taxYearRepository->shouldReceive('save')->once()->with($taxYear);
 
-    $updateNonAttributableAllowableCost->handle($taxYearRepository);
+    $updateNonAttributableAllowableCost($taxYearRepository);
 
     $taxYear->shouldHaveReceived('updateNonAttributableAllowableCost')->once()->with($updateNonAttributableAllowableCost);
 });


### PR DESCRIPTION
## Summary

This PR makes actions invokable instead of relying on the `handle` method.

## Explanation

Laravel automatically tries to use dispatched job as invokable classes as well as calling the `handle` method – the latter makes for some cleaner classes.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
