### PR TITLE
Quantity allocation refactoring and other fixes

### DIFF
--- a/domain/src/Aggregates/SharePoolingAsset/Entities/Exceptions/SharePoolingAssetAcquisitionException.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/Exceptions/SharePoolingAssetAcquisitionException.php
@@ -19,21 +19,34 @@ final class SharePoolingAssetAcquisitionException extends RuntimeException
         return new self(sprintf('The allocated quantity %s exceeds the available quantity %s', $allocated, $available));
     }
 
-    public static function insufficientSameDayQuantity(Quantity $quantity, Quantity $sameDayQuantity): self
+    public static function insufficientSameDayQuantityToIncrease(Quantity $quantity, Quantity $availableQuantity): self
     {
-        return new self(sprintf(
-            'Cannot decrease same-day quantity by %s: only %s available',
-            $quantity,
-            $sameDayQuantity,
-        ));
+        return self::insufficientQuantity($quantity, $availableQuantity, 'same-day', 'increase');
     }
 
-    public static function insufficientThirtyDayQuantity(Quantity $quantity, Quantity $thirtyDayQuantity): self
+    public static function insufficientSameDayQuantityToDecrease(Quantity $quantity, Quantity $availableQuantity): self
+    {
+        return self::insufficientQuantity($quantity, $availableQuantity, 'same-day', 'decrease');
+    }
+
+    public static function insufficientThirtyDayQuantityToIncrease(Quantity $quantity, Quantity $availableQuantity): self
+    {
+        return self::insufficientQuantity($quantity, $availableQuantity, '30-day', 'increase');
+    }
+
+    public static function insufficientThirtyDayQuantityToDecrease(Quantity $quantity, Quantity $availableQuantity): self
+    {
+        return self::insufficientQuantity($quantity, $availableQuantity, '30-day', 'decrease');
+    }
+
+    private static function insufficientQuantity(Quantity $quantity, Quantity $availableQuantity, string $type, string $action): self
     {
         return new self(sprintf(
-            'Cannot decrease 30-day quantity by %s: only %s available',
+            'Cannot %s %s quantity by %s: only %s available',
+            $action,
+            $type,
             $quantity,
-            $thirtyDayQuantity,
+            $availableQuantity,
         ));
     }
 }

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisition.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisition.php
@@ -74,8 +74,12 @@ final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction
         return $this;
     }
 
-    /** Increase the same-day quantity and adjust the 30-day quantity accordingly. */
-    public function increaseSameDayQuantityUpToAvailableQuantity(Quantity $quantity): self
+    /**
+     * Increase the same-day quantity and adjust the 30-day quantity accordingly.
+     *
+     * @return Quantity the added quantity
+     */
+    public function increaseSameDayQuantityUpToAvailableQuantity(Quantity $quantity): Quantity
     {
         // Adjust same-day quantity
         $quantityToAdd = Quantity::minimum($quantity, $this->availableSameDayQuantity());
@@ -85,7 +89,7 @@ final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction
         $quantityToDeduct = Quantity::minimum($quantityToAdd, $this->thirtyDayQuantity);
         $this->thirtyDayQuantity = $this->thirtyDayQuantity->minus($quantityToDeduct);
 
-        return $this;
+        return $quantityToAdd;
     }
 
     /** @throws SharePoolingAssetAcquisitionException */
@@ -111,12 +115,13 @@ final class SharePoolingAssetAcquisition extends SharePoolingAssetTransaction
         return $this;
     }
 
-    public function increaseThirtyDayQuantityUpToAvailableQuantity(Quantity $quantity): self
+    /** @return Quantity the added quantity */
+    public function increaseThirtyDayQuantityUpToAvailableQuantity(Quantity $quantity): Quantity
     {
         $quantityToAdd = Quantity::minimum($quantity, $this->availableThirtyDayQuantity());
         $this->thirtyDayQuantity = $this->thirtyDayQuantity->plus($quantityToAdd);
 
-        return $this;
+        return $quantityToAdd;
     }
 
     /** @throws SharePoolingAssetAcquisitionException */

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposals.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposals.php
@@ -65,16 +65,6 @@ final class SharePoolingAssetDisposals implements IteratorAggregate
         return new self(array_reverse($this->disposals));
     }
 
-    public function unprocessed(): SharePoolingAssetDisposals
-    {
-        $disposals = array_filter(
-            $this->disposals,
-            fn (SharePoolingAssetDisposal $disposal) => ! $disposal->processed,
-        );
-
-        return self::make(...$disposals);
-    }
-
     public function withAvailableSameDayQuantity(): SharePoolingAssetDisposals
     {
         $disposals = array_filter(

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
@@ -51,8 +51,11 @@ abstract class SharePoolingAssetTransaction implements Stringable
         return $this->availableSameDayQuantity()->isGreaterThan('0');
     }
 
+    /** Return the quantity that is not yet allocated as same-day quantity. */
     public function availableSameDayQuantity(): Quantity
     {
+        // Same-day quantity always gets priority, so any quantity that is not yet
+        // allocated as same-day quantity is technically available as same-day quantity
         return $this->quantity->minus($this->sameDayQuantity());
     }
 

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransaction.php
@@ -64,7 +64,7 @@ abstract class SharePoolingAssetTransaction implements Stringable
     public function availableThirtyDayQuantity(): Quantity
     {
         // Same-day quantity always gets priority, and it is assumed that the existing
-        // 30-day quantity has already been matched with priority transactions. That
+        // 30-day quantity has already been allocated to priority transactions. That
         // leaves us with the section 104 pool quantity, which is what we return
         return $this->section104PoolQuantity();
     }

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactions.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactions.php
@@ -267,7 +267,7 @@ final class SharePoolingAssetTransactions implements IteratorAggregate
         return $this->disposalsMadeAfter($date->minusDays(1));
     }
 
-    public function disposalsWithThirtyDayQuantityMatchedWith(SharePoolingAssetAcquisition $acquisition): SharePoolingAssetDisposals
+    public function disposalsWithThirtyDayQuantityAllocatedTo(SharePoolingAssetAcquisition $acquisition): SharePoolingAssetDisposals
     {
         $transactions = array_filter(
             $this->transactions,

--- a/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactions.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactions.php
@@ -63,6 +63,11 @@ final class SharePoolingAssetTransactions implements IteratorAggregate
         return count($this->transactions);
     }
 
+    public function copy(): self
+    {
+        return new self(array_map(fn (SharePoolingAssetTransaction $transaction) => clone $transaction, $this->transactions));
+    }
+
     public function first(): ?SharePoolingAssetTransaction
     {
         return $this->transactions[0] ?? null;

--- a/domain/src/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjuster.php
+++ b/domain/src/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjuster.php
@@ -13,11 +13,11 @@ use Domain\Aggregates\SharePoolingAsset\Services\QuantityAdjuster\Exceptions\Qua
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\QuantityAllocation;
 
 /**
- * This service restores the quantities from acquisitions that were
- * previously matched with a disposal that is now being reverted.
+ * This service restores acquisition quantities that were previously allocated to a disposal that is now being reverted.
  */
 final class QuantityAdjuster
 {
+    /** @throws SharePoolingAssetAcquisitionException */
     public static function revertDisposal(
         SharePoolingAssetDisposal $disposal,
         SharePoolingAssetTransactions $transactions,

--- a/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
@@ -118,7 +118,7 @@ final class SharePoolingAsset implements SharePoolingAssetContract
         $this->revertDisposals($disposalsToRevert);
 
         // Add the current disposal to the transactions (as unprocessed) so previous disposals
-        // don't try to match their 30-day quantity with the disposal's same-day acquisitions
+        // don't try to allocate their 30-day quantity to the disposal's same-day acquisitions
         $this->transactions->add(new SharePoolingAssetDisposal(
             id: $action->transactionId,
             date: $action->date,
@@ -176,9 +176,10 @@ final class SharePoolingAsset implements SharePoolingAssetContract
 
     public function applySharePoolingAssetDisposalReverted(SharePoolingAssetDisposalReverted $event): void
     {
-        // Replace the disposal in the array with the same disposal, but with reset quantities. This
-        // way, when several disposals are being replayed, a disposal won't be matched with future
-        // acquisitions within the next 30 days if these acquisitions have disposals on the same day
+        // Replace the disposal in the array with the same disposal, with reset quantities. This way,
+        // when several disposals are being replayed, we're sure the quantities of acquisitions made
+        // within 30 days of a disposal won't be wrongly allocated to that disposal instead of some
+        // disposals that might have happened on the same day as the acquisitions
         $this->transactions->add($event->disposal->copyAsUnprocessed());
     }
 

--- a/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
+++ b/domain/src/Aggregates/SharePoolingAsset/SharePoolingAsset.php
@@ -66,7 +66,7 @@ final class SharePoolingAsset implements SharePoolingAssetContract
 
         $disposalsToRevert = ReversionFinder::disposalsToRevertOnAcquisition(
             acquisition: $action,
-            transactions: $this->transactions->copy(),
+            transactions: $this->transactions,
         );
 
         $disposalsToRevert->isEmpty() || $this->revertDisposals($disposalsToRevert);
@@ -96,7 +96,7 @@ final class SharePoolingAsset implements SharePoolingAssetContract
         // acquisition's same-day and 30-day quantities, these updates occur before the acquisition's event
         // is recorded, meaning the event is stored with the updated quantities. As a result, whenever the
         // aggregate is recreated from its events, the acquisition already has a same-day and/or 30-day
-        // quantity, but upon replaying the subsequent disposals, these quantities are updated *again*.
+        // quantity, but upon replaying the subsequent disposals, these quantities are updated *again*
         $this->transactions->add(clone $event->acquisition);
     }
 
@@ -111,12 +111,12 @@ final class SharePoolingAsset implements SharePoolingAssetContract
 
         $disposalsToRevert = ReversionFinder::disposalsToRevertOnDisposal(
             disposal: $action,
-            transactions: $this->transactions->copy(),
+            transactions: $this->transactions,
         );
 
         $disposalsToRevert->isEmpty() || $this->revertDisposals($disposalsToRevert);
 
-        $sharePoolingAssetDisposal = DisposalBuilder::process(
+        $sharePoolingAssetDisposal = DisposalBuilder::make(
             disposal: $action,
             transactions: $this->transactions->copy(),
         );

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
@@ -109,7 +109,12 @@ it('can increase the same-day quantity', function (string $increase, string $sam
     'scenario 2' => ['10', '40'],
 ]);
 
-it('can increase the same-day quantity up to the available quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+it('can increase the same-day quantity up to the available quantity', function (
+    string $increase,
+    string $sameDayQuantity,
+    string $thirtyDayQuantity,
+    string $addedQuantity,
+) {
     /** @var SharePoolingAssetAcquisition */
     $acquisition = SharePoolingAssetAcquisition::factory()->make([
         'quantity' => new Quantity('100'),
@@ -117,15 +122,16 @@ it('can increase the same-day quantity up to the available quantity', function (
         'thirtyDayQuantity' => new Quantity('60'),
     ]);
 
-    $acquisition->increaseSameDayQuantityUpToAvailableQuantity(new Quantity($increase));
+    $added = $acquisition->increaseSameDayQuantityUpToAvailableQuantity(new Quantity($increase));
 
     expect((string) $acquisition->sameDayQuantity())->toBe($sameDayQuantity);
     expect((string) $acquisition->thirtyDayQuantity())->toBe($thirtyDayQuantity);
+    expect((string) $added)->toBe($addedQuantity);
 })->with([
-    'scenario 1' => ['5', '35', '55'],
-    'scenario 2' => ['10', '40', '50'],
-    'scenario 3' => ['70', '100', '0'],
-    'scenario 4' => ['71', '100', '0'],
+    'scenario 1' => ['5', '35', '55', '5'],
+    'scenario 2' => ['10', '40', '50', '10'],
+    'scenario 3' => ['70', '100', '0', '70'],
+    'scenario 4' => ['71', '100', '0', '70'],
 ]);
 
 it('cannot decrease the same-day quantity because the quantity is too great', function () {
@@ -185,7 +191,12 @@ it('can increase the 30-day quantity', function (string $increase, string $thirt
     'scenario 2' => ['10', '70'],
 ]);
 
-it('can increase the 30-day quantity up to the available quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+it('can increase the 30-day quantity up to the available quantity', function (
+    string $increase,
+    string $sameDayQuantity,
+    string $thirtyDayQuantity,
+    string $addedQuantity,
+) {
     /** @var SharePoolingAssetAcquisition */
     $acquisition = SharePoolingAssetAcquisition::factory()->make([
         'quantity' => new Quantity('100'),
@@ -193,14 +204,15 @@ it('can increase the 30-day quantity up to the available quantity', function (st
         'thirtyDayQuantity' => new Quantity('60'),
     ]);
 
-    $acquisition->increaseThirtyDayQuantityUpToAvailableQuantity(new Quantity($increase));
+    $added = $acquisition->increaseThirtyDayQuantityUpToAvailableQuantity(new Quantity($increase));
 
     expect((string) $acquisition->sameDayQuantity())->toBe($sameDayQuantity);
     expect((string) $acquisition->thirtyDayQuantity())->toBe($thirtyDayQuantity);
+    expect((string) $added)->toBe($addedQuantity);
 })->with([
-    'scenario 1' => ['5', '30', '65'],
-    'scenario 2' => ['10', '30', '70'],
-    'scenario 3' => ['15', '30', '70'],
+    'scenario 1' => ['5', '30', '65', '5'],
+    'scenario 2' => ['10', '30', '70', '10'],
+    'scenario 3' => ['15', '30', '70', '10'],
 ]);
 
 it('cannot decrease the 30-day quantity because the quantity is too great', function () {

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetAcquisitionTest.php
@@ -63,6 +63,7 @@ it('can return the section 104 pool cost basis', function (string $quantity, str
 it('can return the various quantities', function () {
     /** @var SharePoolingAssetAcquisition */
     $acquisition = SharePoolingAssetAcquisition::factory()->make([
+        'quantity' => new Quantity('100'),
         'sameDayQuantity' => new Quantity('30'),
         'thirtyDayQuantity' => new Quantity('60'),
     ]);
@@ -78,7 +79,21 @@ it('can return the various quantities', function () {
     expect((string) $acquisition->availableThirtyDayQuantity())->toBe('10');
 });
 
-it('can increase the same-day quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+it('cannot increase the same-day quantity because the quantity is too great', function () {
+    /** @var SharePoolingAssetAcquisition */
+    $acquisition = SharePoolingAssetAcquisition::factory()->make([
+        'quantity' => new Quantity('100'),
+        'sameDayQuantity' => new Quantity('30'),
+        'thirtyDayQuantity' => new Quantity('60'),
+    ]);
+
+    expect(fn () => $acquisition->increaseSameDayQuantity(new Quantity('11')))->toThrow(
+        SharePoolingAssetAcquisitionException::class,
+        SharePoolingAssetAcquisitionException::insufficientSameDayQuantityToIncrease(new Quantity('11'), new Quantity('10'))->getMessage(),
+    );
+});
+
+it('can increase the same-day quantity', function (string $increase, string $sameDayQuantity) {
     /** @var SharePoolingAssetAcquisition */
     $acquisition = SharePoolingAssetAcquisition::factory()->make([
         'quantity' => new Quantity('100'),
@@ -87,6 +102,22 @@ it('can increase the same-day quantity', function (string $increase, string $sam
     ]);
 
     $acquisition->increaseSameDayQuantity(new Quantity($increase));
+
+    expect((string) $acquisition->sameDayQuantity())->toBe($sameDayQuantity);
+})->with([
+    'scenario 1' => ['5', '35'],
+    'scenario 2' => ['10', '40'],
+]);
+
+it('can increase the same-day quantity up to the available quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+    /** @var SharePoolingAssetAcquisition */
+    $acquisition = SharePoolingAssetAcquisition::factory()->make([
+        'quantity' => new Quantity('100'),
+        'sameDayQuantity' => new Quantity('30'),
+        'thirtyDayQuantity' => new Quantity('60'),
+    ]);
+
+    $acquisition->increaseSameDayQuantityUpToAvailableQuantity(new Quantity($increase));
 
     expect((string) $acquisition->sameDayQuantity())->toBe($sameDayQuantity);
     expect((string) $acquisition->thirtyDayQuantity())->toBe($thirtyDayQuantity);
@@ -107,7 +138,7 @@ it('cannot decrease the same-day quantity because the quantity is too great', fu
 
     expect(fn () => $acquisition->decreaseSameDayQuantity(new Quantity('31')))->toThrow(
         SharePoolingAssetAcquisitionException::class,
-        SharePoolingAssetAcquisitionException::insufficientSameDayQuantity(new Quantity('31'), new Quantity('30'))->getMessage(),
+        SharePoolingAssetAcquisitionException::insufficientSameDayQuantityToDecrease(new Quantity('31'), new Quantity('30'))->getMessage(),
     );
 });
 
@@ -124,7 +155,21 @@ it('can decrease the same-day quantity', function () {
     expect((string) $acquisition->sameDayQuantity())->toBe('20');
 });
 
-it('can increase the 30-day quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+it('cannot increase the 30-day quantity because the quantity is too great', function () {
+    /** @var SharePoolingAssetAcquisition */
+    $acquisition = SharePoolingAssetAcquisition::factory()->make([
+        'quantity' => new Quantity('100'),
+        'sameDayQuantity' => new Quantity('30'),
+        'thirtyDayQuantity' => new Quantity('60'),
+    ]);
+
+    expect(fn () => $acquisition->increaseThirtyDayQuantity(new Quantity('11')))->toThrow(
+        SharePoolingAssetAcquisitionException::class,
+        SharePoolingAssetAcquisitionException::insufficientThirtyDayQuantityToIncrease(new Quantity('11'), new Quantity('10'))->getMessage(),
+    );
+});
+
+it('can increase the 30-day quantity', function (string $increase, string $thirtyDayQuantity) {
     /** @var SharePoolingAssetAcquisition */
     $acquisition = SharePoolingAssetAcquisition::factory()->make([
         'quantity' => new Quantity('100'),
@@ -133,6 +178,22 @@ it('can increase the 30-day quantity', function (string $increase, string $sameD
     ]);
 
     $acquisition->increaseThirtyDayQuantity(new Quantity($increase));
+
+    expect((string) $acquisition->thirtyDayQuantity())->toBe($thirtyDayQuantity);
+})->with([
+    'scenario 1' => ['5', '65'],
+    'scenario 2' => ['10', '70'],
+]);
+
+it('can increase the 30-day quantity up to the available quantity', function (string $increase, string $sameDayQuantity, string $thirtyDayQuantity) {
+    /** @var SharePoolingAssetAcquisition */
+    $acquisition = SharePoolingAssetAcquisition::factory()->make([
+        'quantity' => new Quantity('100'),
+        'sameDayQuantity' => new Quantity('30'),
+        'thirtyDayQuantity' => new Quantity('60'),
+    ]);
+
+    $acquisition->increaseThirtyDayQuantityUpToAvailableQuantity(new Quantity($increase));
 
     expect((string) $acquisition->sameDayQuantity())->toBe($sameDayQuantity);
     expect((string) $acquisition->thirtyDayQuantity())->toBe($thirtyDayQuantity);
@@ -152,7 +213,7 @@ it('cannot decrease the 30-day quantity because the quantity is too great', func
 
     expect(fn () => $acquisition->decreaseThirtyDayQuantity(new Quantity('61')))->toThrow(
         SharePoolingAssetAcquisitionException::class,
-        SharePoolingAssetAcquisitionException::insufficientThirtyDayQuantity(new Quantity('61'), new Quantity('60'))->getMessage(),
+        SharePoolingAssetAcquisitionException::insufficientThirtyDayQuantityToDecrease(new Quantity('61'), new Quantity('60'))->getMessage(),
     );
 });
 

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalsTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetDisposalsTest.php
@@ -69,22 +69,6 @@ it('can reverse a collection of disposals', function () {
     expect($disposals->getIterator()[2])->toBe($disposal1);
 });
 
-it('can return the unprocessed disposals from a collection of disposals', function () {
-    /** @var list<SharePoolingAssetDisposal> */
-    $items = [
-        SharePoolingAssetDisposal::factory()->make(),
-        $unprocessed1 = SharePoolingAssetDisposal::factory()->unprocessed()->make(),
-        SharePoolingAssetDisposal::factory()->make(),
-        $unprocessed2 = SharePoolingAssetDisposal::factory()->unprocessed()->make(),
-    ];
-
-    $disposals = SharePoolingAssetDisposals::make(...$items)->unprocessed();
-
-    expect($disposals->count())->toBeInt()->toBe(2);
-    expect($disposals->getIterator()[0])->toBe($unprocessed1);
-    expect($disposals->getIterator()[1])->toBe($unprocessed2);
-});
-
 it('can return the disposals with available same-day quantity from a collection of disposals', function () {
     /** @var list<SharePoolingAssetDisposal> */
     $items = [

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactionsTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactionsTest.php
@@ -39,6 +39,21 @@ it('can make a collection of transactions', function () {
     expect($transactions->count())->toBeInt()->toBe(3);
 });
 
+it('can return a copy of a collection of transactions', function () {
+    /** @var list<SharePoolingAssetTransaction> */
+    $items = [
+        $first = SharePoolingAssetAcquisition::factory()->make(),
+        $second = SharePoolingAssetDisposal::factory()->make(),
+    ];
+
+    $transactions = SharePoolingAssetTransactions::make(...$items)->copy();
+
+    expect($first)->not->toBe($transactions->get(0));
+    expect($second)->not->toBe($transactions->get(1));
+    expect($first)->toEqual($transactions->get(0));
+    expect($second)->toEqual($transactions->get(1));
+});
+
 it('can return the first transaction of a collection', function () {
     /** @var list<SharePoolingAssetTransaction> */
     $items = [

--- a/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactionsTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Entities/SharePoolingAssetTransactionsTest.php
@@ -502,7 +502,7 @@ it('can return a collection of disposals with 30-day quantity allocated to an ac
         SharePoolingAssetDisposal::factory()->withThirtyDayQuantity(new Quantity('20'), id: $acquisition2->id)->make(),
         $disposal2 = SharePoolingAssetDisposal::factory()->withThirtyDayQuantity(new Quantity('70'), id: $acquisition1->id)->make(),
         SharePoolingAssetDisposal::factory()->make(),
-    )->disposalsWithThirtyDayQuantityMatchedWith($acquisition1);
+    )->disposalsWithThirtyDayQuantityAllocatedTo($acquisition1);
 
     expect($transactions)->toBeInstanceOf(SharePoolingAssetDisposals::class);
     expect($transactions->count())->toEqual(2);

--- a/domain/tests/Aggregates/SharePoolingAsset/Services/DisposalBuilder/DisposalBuilderTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Services/DisposalBuilder/DisposalBuilderTest.php
@@ -4,7 +4,7 @@ use Brick\DateTime\LocalDate;
 use Domain\Aggregates\SharePoolingAsset\Actions\DisposeOfSharePoolingAsset;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetTransactions;
-use Domain\Aggregates\SharePoolingAsset\Services\DisposalProcessor\DisposalProcessor;
+use Domain\Aggregates\SharePoolingAsset\Services\DisposalBuilder\DisposalBuilder;
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
 use Domain\ValueObjects\Asset;
 use Domain\ValueObjects\FiatAmount;
@@ -20,7 +20,7 @@ it('does not process any acquisitions when the disposed of quantity is zero', fu
         forFiat: false,
     );
 
-    $disposal = DisposalProcessor::process(
+    $disposal = DisposalBuilder::process(
         disposal: $action,
         transactions: SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make()),
     );
@@ -40,7 +40,7 @@ it('does not process any section 104 pool acquisitions when none were made befor
 
     $acquisition = SharePoolingAssetAcquisition::factory()->make(['date' => LocalDate::parse('2021-10-22')]);
 
-    $disposal = DisposalProcessor::process($action, SharePoolingAssetTransactions::make($acquisition));
+    $disposal = DisposalBuilder::process($action, SharePoolingAssetTransactions::make($acquisition));
 
     expect($disposal->id)->toBe($id);
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Services/DisposalBuilder/DisposalBuilderTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Services/DisposalBuilder/DisposalBuilderTest.php
@@ -20,7 +20,7 @@ it('does not process any acquisitions when the disposed of quantity is zero', fu
         forFiat: false,
     );
 
-    $disposal = DisposalBuilder::process(
+    $disposal = DisposalBuilder::make(
         disposal: $action,
         transactions: SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make()),
     );
@@ -40,7 +40,7 @@ it('does not process any section 104 pool acquisitions when none were made befor
 
     $acquisition = SharePoolingAssetAcquisition::factory()->make(['date' => LocalDate::parse('2021-10-22')]);
 
-    $disposal = DisposalBuilder::process($action, SharePoolingAssetTransactions::make($acquisition));
+    $disposal = DisposalBuilder::make($action, SharePoolingAssetTransactions::make($acquisition));
 
     expect($disposal->id)->toBe($id);
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjusterTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjusterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Domain\Aggregates\SharePoolingAsset\Entities\Exceptions\SharePoolingAssetAcquisitionException;
+use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetTransactions;
 use Domain\Aggregates\SharePoolingAsset\Services\QuantityAdjuster\Exceptions\QuantityAdjusterException;
@@ -7,22 +9,106 @@ use Domain\Aggregates\SharePoolingAsset\Services\QuantityAdjuster\QuantityAdjust
 use Domain\Aggregates\SharePoolingAsset\ValueObjects\SharePoolingAssetTransactionId;
 use Domain\ValueObjects\Quantity;
 
-it('cannot revert a disposal because an acquisition cannot be found', function () {
+it('cannot process a disposal because an acquisition cannot be found', function (string $method) {
     $disposal = SharePoolingAssetDisposal::factory()
         ->withSameDayQuantity(Quantity::zero(), $id = SharePoolingAssetTransactionId::fromString('foo'))
         ->make();
 
-    expect(fn () => QuantityAdjuster::revertDisposal($disposal, SharePoolingAssetTransactions::make()))
+    expect(fn () => QuantityAdjuster::$method($disposal, SharePoolingAssetTransactions::make()))
         ->toThrow(QuantityAdjusterException::class, QuantityAdjusterException::transactionNotFound($id)->getMessage());
-});
+})->with(['applyDisposal', 'revertDisposal']);
 
-it('cannot revert a disposal because a transaction is not an acquisition', function () {
+it('cannot process a disposal because a transaction is not an acquisition', function (string $method) {
     $disposal = SharePoolingAssetDisposal::factory()
         ->withSameDayQuantity(Quantity::zero(), $id = SharePoolingAssetTransactionId::fromString('foo'))
         ->make();
 
     $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetDisposal::factory()->make(['id' => $id]));
 
-    expect(fn () => QuantityAdjuster::revertDisposal($disposal, $transactions))
+    expect(fn () => QuantityAdjuster::$method($disposal, $transactions))
         ->toThrow(QuantityAdjusterException::class, QuantityAdjusterException::notAnAcquisition($id)->getMessage());
-});
+})->with(['applyDisposal', 'revertDisposal']);
+
+it('cannot apply a disposal because of insufficient available quantity to increase', function (
+    string $method,
+    string $quantity,
+    string $exception
+) {
+    $disposal = SharePoolingAssetDisposal::factory()
+        ->{$method}(new Quantity($quantity), $id = SharePoolingAssetTransactionId::fromString('foo'))
+        ->make();
+
+    $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make([
+        'id' => $id,
+        'quantity' => $available = new Quantity('10'),
+    ]));
+
+    expect(fn () => QuantityAdjuster::applyDisposal($disposal, $transactions))->toThrow(
+        SharePoolingAssetAcquisitionException::class,
+        SharePoolingAssetAcquisitionException::$exception(new Quantity($quantity), $available)->getMessage(),
+    );
+})->with([
+    'same-day' => ['withSameDayQuantity', '11', 'insufficientSameDayQuantityToIncrease'],
+    '30-day' => ['withThirtyDayQuantity', '11', 'insufficientThirtyDayQuantityToIncrease'],
+]);
+
+it('can apply a disposal', function (string $factoryMethod, string $method) {
+    $disposal = SharePoolingAssetDisposal::factory()
+        ->{$factoryMethod}(new Quantity('10'), $id = SharePoolingAssetTransactionId::fromString('foo'))
+        ->make();
+
+    $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make([
+        'id' => $id,
+        'quantity' => new Quantity('10'),
+    ]));
+
+    expect((string) $transactions->first()->{$method}())->toBe('0');
+
+    QuantityAdjuster::applyDisposal($disposal, $transactions);
+
+    expect((string) $transactions->first()->{$method}())->toBe('10');
+})->with([
+    'same-day' => ['withSameDayQuantity', 'sameDayQuantity'],
+    '30-day' => ['withThirtyDayQuantity', 'thirtyDayQuantity'],
+]);
+
+it('cannot revert a disposal because of insufficient available quantity to decrease', function (
+    string $method,
+    string $quantity,
+    string $exception
+) {
+    $disposal = SharePoolingAssetDisposal::factory()
+        ->{$method}(new Quantity($quantity), $id = SharePoolingAssetTransactionId::fromString('foo'))
+        ->make();
+
+    $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make(['id' => $id]));
+
+    expect(fn () => QuantityAdjuster::revertDisposal($disposal, $transactions))->toThrow(
+        SharePoolingAssetAcquisitionException::class,
+        SharePoolingAssetAcquisitionException::$exception(new Quantity($quantity), Quantity::zero())->getMessage(),
+    );
+})->with([
+    'same-day' => ['withSameDayQuantity', '1', 'insufficientSameDayQuantityToDecrease'],
+    '30-day' => ['withThirtyDayQuantity', '1', 'insufficientThirtyDayQuantityToDecrease'],
+]);
+
+it('can revert a disposal', function (string $factoryMethod, string $method) {
+    $disposal = SharePoolingAssetDisposal::factory()
+        ->{$factoryMethod}(new Quantity('10'), $id = SharePoolingAssetTransactionId::fromString('foo'))
+        ->make();
+
+    $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make([
+        'id' => $id,
+        'sameDayQuantity' => new Quantity('10'),
+        'thirtyDayQuantity' => new Quantity('10'),
+    ]));
+
+    expect((string) $transactions->first()->{$method}())->toBe('10');
+
+    QuantityAdjuster::revertDisposal($disposal, $transactions);
+
+    expect((string) $transactions->first()->{$method}())->toBe('0');
+})->with([
+    'same-day' => ['withSameDayQuantity', 'sameDayQuantity'],
+    '30-day' => ['withThirtyDayQuantity', 'thirtyDayQuantity'],
+]);

--- a/domain/tests/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjusterTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/Services/QuantityAdjuster/QuantityAdjusterTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetAcquisition;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetDisposal;
 use Domain\Aggregates\SharePoolingAsset\Entities\SharePoolingAssetTransactions;
 use Domain\Aggregates\SharePoolingAsset\Services\QuantityAdjuster\Exceptions\QuantityAdjusterException;
@@ -26,14 +25,4 @@ it('cannot revert a disposal because a transaction is not an acquisition', funct
 
     expect(fn () => QuantityAdjuster::revertDisposal($disposal, $transactions))
         ->toThrow(QuantityAdjusterException::class, QuantityAdjusterException::notAnAcquisition($id)->getMessage());
-});
-
-it('reverts a disposal despite insufficient same-day quantity', function () {
-    $disposal = SharePoolingAssetDisposal::factory()
-        ->withSameDayQuantity(new Quantity('100'), $id = SharePoolingAssetTransactionId::fromString('foo'))
-        ->make();
-
-    $transactions = SharePoolingAssetTransactions::make(SharePoolingAssetAcquisition::factory()->make(['id' => $id]));
-
-    expect(QuantityAdjuster::revertDisposal($disposal, $transactions))->not->toThrow(QuantityAdjusterException::class);
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
@@ -287,7 +287,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
     ));
 });
 
-it('can dispose of a share pooling asset on the same day they were acquired', function () {
+it('can dispose of a share pooling asset on the same day it was acquired', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -392,7 +392,7 @@ it('can use the average cost basis per unit of a section 104 pool to calculate t
     ));
 });
 
-it('can acquire a share pooling asset within 30 days of their disposal', function () {
+it('can acquire a share pooling asset within 30 days of its disposal', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -432,7 +432,6 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
                 quantity: $acquireMoreSharePoolingAsset->quantity,
                 costBasis: $acquireMoreSharePoolingAsset->costBasis,
                 forFiat: false,
-                thirtyDayQuantity: new Quantity('25'),
             ),
         ),
         new SharePoolingAssetDisposedOf(
@@ -447,7 +446,7 @@ it('can acquire a share pooling asset within 30 days of their disposal', functio
     );
 });
 
-it('can acquire a share pooling asset several times within 30 days of their disposal', function () {
+it('can acquire a share pooling asset several times within 30 days of its disposal', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -465,7 +464,6 @@ it('can acquire a share pooling asset several times within 30 days of their disp
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
             forFiat: false,
-            sameDayQuantity: new Quantity('25'),
         ),
     ));
 
@@ -489,17 +487,16 @@ it('can acquire a share pooling asset several times within 30 days of their disp
         ),
     ));
 
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
+
     given($sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
             forFiat: false,
-            thirtyDayQuantity: new Quantity('20'),
         ),
     ));
-
-    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
 
     given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
@@ -527,7 +524,6 @@ it('can acquire a share pooling asset several times within 30 days of their disp
                 quantity: $acquireSharePoolingAsset4->quantity,
                 costBasis: $acquireSharePoolingAsset4->costBasis,
                 forFiat: false,
-                thirtyDayQuantity: new Quantity('20'),
             ),
         ),
         new SharePoolingAssetDisposedOf(
@@ -563,7 +559,6 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
             quantity: new Quantity('25'),
             costBasis: FiatAmount::GBP('50'),
             forFiat: false,
-            sameDayQuantity: new Quantity('25'),
         ),
     ));
 
@@ -586,17 +581,16 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
             ]),
     ));
 
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
+
     given($sharePoolingAssetAcquired3 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-28'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('60'),
             forFiat: false,
-            thirtyDayQuantity: new Quantity('20'),
         ),
     ));
-
-    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
 
     given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
@@ -605,21 +599,18 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
             ->make(['costBasis' => FiatAmount::GBP('115')]),
     ));
 
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2->disposal));
+
     given($sharePoolingAssetAcquired4 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
             date: LocalDate::parse('2015-10-29'),
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('40'),
             forFiat: false,
-            thirtyDayQuantity: new Quantity('20'),
         ),
     ));
-
-    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
-
-    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2->disposal));
-
-    given(new SharePoolingAssetDisposedOf(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
 
     given(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
@@ -632,7 +623,7 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf2->disposal)
             ->withThirtyDayQuantity(new Quantity('15'), id: $sharePoolingAssetAcquired4->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('40')]),
+            ->make(['costBasis' => FiatAmount::GBP('35')]),
     ));
 
     when($disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
@@ -648,12 +639,6 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
         new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2Corrected1->disposal),
         new SharePoolingAssetDisposedOf(
             disposal: SharePoolingAssetDisposal::factory()
-                ->revert($sharePoolingAssetDisposedOf2->disposal)
-                ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
-                ->make(['costBasis' => FiatAmount::GBP('30')]),
-        ),
-        new SharePoolingAssetDisposedOf(
-            disposal: SharePoolingAssetDisposal::factory()
                 ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired4->acquisition->id)
                 ->make([
                     'id' => $disposeOfSharePoolingAsset3->transactionId,
@@ -661,13 +646,79 @@ it('can dispose of a share pooling asset on the same day as an acquisition withi
                     'quantity' => $disposeOfSharePoolingAsset3->quantity,
                     'costBasis' => FiatAmount::GBP('20'),
                     'proceeds' => $disposeOfSharePoolingAsset3->proceeds,
-                    'thirtyDayQuantityAllocation' => new QuantityAllocation(),
                 ]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOf2->disposal)
+                ->withThirtyDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired4->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('30')]),
         ),
     );
 });
 
-it('can acquire a same-day share pooling asset several times on the same day as their disposal', function () {
+it('can acquire a share pooling asset within 30 days of a disposal that was on the same day as an acquisition', function () {
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
+
+    given(new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-10-21'),
+            quantity: new Quantity('30'),
+            costBasis: FiatAmount::GBP('60'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetAcquired = new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-11-25'),
+            quantity: new Quantity('40'),
+            costBasis: FiatAmount::GBP('40'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetDisposedOf = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->withSameDayQuantity(new Quantity('40'), id: $sharePoolingAssetAcquired->acquisition->id)
+            ->make([
+                'date' => LocalDate::parse('2015-11-25'),
+                'quantity' => new Quantity('50'),
+                'costBasis' => FiatAmount::GBP('60'),
+            ]),
+    ));
+
+    when($acquireSharePoolingAsset = new AcquireSharePoolingAsset(
+        transactionId: SharePoolingAssetTransactionId::generate(),
+        asset: $this->aggregateRootId->toAsset(),
+        date: LocalDate::parse('2015-11-28'),
+        quantity: new Quantity('40'),
+        costBasis: FiatAmount::GBP('20'),
+        forFiat: false,
+    ));
+
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf->disposal),
+        new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireSharePoolingAsset->transactionId,
+                date: $acquireSharePoolingAsset->date,
+                quantity: $acquireSharePoolingAsset->quantity,
+                costBasis: $acquireSharePoolingAsset->costBasis,
+                forFiat: false,
+            ),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOf->disposal)
+                ->withSameDayQuantity(new Quantity('40'), id: $sharePoolingAssetAcquired->acquisition->id)
+                ->withThirtyDayQuantity(new Quantity('10'), id: $acquireSharePoolingAsset->transactionId)
+                ->make(['costBasis' => FiatAmount::GBP('45')]),
+        ),
+    );
+});
+
+it('can acquire a same-day share pooling asset several times on the same day as its disposal', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -697,7 +748,6 @@ it('can acquire a same-day share pooling asset several times on the same day as 
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
             forFiat: false,
-            sameDayQuantity: new Quantity('20'), // $sharePoolingAssetDisposedOf
         ),
     ));
 
@@ -730,7 +780,6 @@ it('can acquire a same-day share pooling asset several times on the same day as 
                 quantity: $acquireSharePoolingAsset3->quantity,
                 costBasis: $acquireSharePoolingAsset3->costBasis,
                 forFiat: false,
-                sameDayQuantity: new Quantity('10'), // $sharePoolingAssetDisposedOf
             ),
         ),
         new SharePoolingAssetDisposedOf(
@@ -773,7 +822,6 @@ it('can dispose of a same-day share pooling asset several times on the same day 
             quantity: new Quantity('20'),
             costBasis: FiatAmount::GBP('25'),
             forFiat: false,
-            sameDayQuantity: new Quantity('20'), // $sharePoolingAssetDisposedOf1
         ),
     ));
 
@@ -792,7 +840,6 @@ it('can dispose of a same-day share pooling asset several times on the same day 
             quantity: new Quantity('60'),
             costBasis: FiatAmount::GBP('90'),
             forFiat: false,
-            sameDayQuantity: new Quantity('30'), // $sharePoolingAssetDisposedOf1
         ),
     ));
 
@@ -823,4 +870,95 @@ it('can dispose of a same-day share pooling asset several times on the same day 
                 'proceeds' => $disposeOfSharePoolingAsset2->proceeds,
             ]),
     ));
+});
+
+it('can acquire and dispose of a share pooling asset several times on the same day and within 30 days of a disposal', function () {
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
+
+    given(new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-10-21'),
+            quantity: new Quantity('100'),
+            costBasis: FiatAmount::GBP('100'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
+        disposal: new SharePoolingAssetDisposal(
+            date: LocalDate::parse('2015-10-22'),
+            quantity: new Quantity('50'),
+            costBasis: FiatAmount::GBP('50'),
+            proceeds: FiatAmount::GBP('75'),
+            forFiat: false,
+        ),
+    ));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
+
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-10-25'),
+            quantity: new Quantity('25'),
+            costBasis: FiatAmount::GBP('20'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+            ->withThirtyDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('45')]),
+    ));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
+
+    given(new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->withSameDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make([
+                'date' => LocalDate::parse('2015-10-25'),
+                'quantity' => new Quantity('5'),
+                'costBasis' => FiatAmount::GBP('4'),
+                'proceeds' => FiatAmount::GBP('10'),
+                'forFiat' => false,
+            ]),
+    ));
+
+    given($sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+            ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('46')]),
+    ));
+
+    when($disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
+        transactionId: SharePoolingAssetTransactionId::generate(),
+        asset: $this->aggregateRootId->toAsset(),
+        date: LocalDate::parse('2015-10-25'),
+        quantity: new Quantity('20'),
+        proceeds: FiatAmount::GBP('50'),
+        forFiat: false,
+    ));
+
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected2->disposal),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+                ->make([
+                    'id' => $disposeOfSharePoolingAsset3->transactionId,
+                    'date' => $disposeOfSharePoolingAsset3->date,
+                    'quantity' => $disposeOfSharePoolingAsset3->quantity,
+                    'costBasis' => FiatAmount::GBP('16'),
+                    'proceeds' => $disposeOfSharePoolingAsset3->proceeds,
+                ]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+                ->make(['costBasis' => FiatAmount::GBP('50')]),
+        ),
+    );
 });

--- a/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
+++ b/domain/tests/Aggregates/SharePoolingAsset/SharePoolingAssetTest.php
@@ -718,7 +718,7 @@ it('can acquire a share pooling asset within 30 days of a disposal that was on t
     );
 });
 
-it('can acquire a same-day share pooling asset several times on the same day as its disposal', function () {
+it('can acquire a share pooling asset several times on the same day as its disposal', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -792,7 +792,7 @@ it('can acquire a same-day share pooling asset several times on the same day as 
     );
 });
 
-it('can dispose of a same-day share pooling asset several times on the same day as several acquisitions', function () {
+it('can dispose of a share pooling asset several times on the same day as several acquisitions', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -872,7 +872,7 @@ it('can dispose of a same-day share pooling asset several times on the same day 
     ));
 });
 
-it('can acquire and dispose of a share pooling asset several times on the same day and within 30 days of a disposal', function () {
+it('can dispose of a share pooling asset several times on the same day and within 30 days of a disposal', function () {
     given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
 
     given(new SharePoolingAssetAcquired(
@@ -887,9 +887,9 @@ it('can acquire and dispose of a share pooling asset several times on the same d
     given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
         disposal: new SharePoolingAssetDisposal(
             date: LocalDate::parse('2015-10-22'),
-            quantity: new Quantity('50'),
-            costBasis: FiatAmount::GBP('50'),
-            proceeds: FiatAmount::GBP('75'),
+            quantity: new Quantity('30'),
+            costBasis: FiatAmount::GBP('30'),
+            proceeds: FiatAmount::GBP('50'),
             forFiat: false,
         ),
     ));
@@ -898,9 +898,9 @@ it('can acquire and dispose of a share pooling asset several times on the same d
 
     given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
         acquisition: new SharePoolingAssetAcquisition(
-            date: LocalDate::parse('2015-10-25'),
-            quantity: new Quantity('25'),
-            costBasis: FiatAmount::GBP('20'),
+            date: LocalDate::parse('2015-10-23'),
+            quantity: new Quantity('20'),
+            costBasis: FiatAmount::GBP('40'),
             forFiat: false,
         ),
     ));
@@ -908,20 +908,20 @@ it('can acquire and dispose of a share pooling asset several times on the same d
     given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
-            ->withThirtyDayQuantity(new Quantity('25'), id: $sharePoolingAssetAcquired2->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('45')]),
+            ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('50')]),
     ));
 
     given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
 
     given(new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
-            ->withSameDayQuantity(new Quantity('5'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
             ->make([
-                'date' => LocalDate::parse('2015-10-25'),
-                'quantity' => new Quantity('5'),
-                'costBasis' => FiatAmount::GBP('4'),
-                'proceeds' => FiatAmount::GBP('10'),
+                'date' => LocalDate::parse('2015-10-23'),
+                'quantity' => new Quantity('10'),
+                'costBasis' => FiatAmount::GBP('20'),
+                'proceeds' => FiatAmount::GBP('30'),
                 'forFiat' => false,
             ]),
     ));
@@ -929,16 +929,16 @@ it('can acquire and dispose of a share pooling asset several times on the same d
     given($sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
         disposal: SharePoolingAssetDisposal::factory()
             ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
-            ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
-            ->make(['costBasis' => FiatAmount::GBP('46')]),
+            ->withThirtyDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('40')]),
     ));
 
     when($disposeOfSharePoolingAsset3 = new DisposeOfSharePoolingAsset(
         transactionId: SharePoolingAssetTransactionId::generate(),
         asset: $this->aggregateRootId->toAsset(),
-        date: LocalDate::parse('2015-10-25'),
-        quantity: new Quantity('20'),
-        proceeds: FiatAmount::GBP('50'),
+        date: LocalDate::parse('2015-10-23'),
+        quantity: new Quantity('15'),
+        proceeds: FiatAmount::GBP('40'),
         forFiat: false,
     ));
 
@@ -946,18 +946,142 @@ it('can acquire and dispose of a share pooling asset several times on the same d
         new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected2->disposal),
         new SharePoolingAssetDisposedOf(
             disposal: SharePoolingAssetDisposal::factory()
-                ->withSameDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+                ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
                 ->make([
                     'id' => $disposeOfSharePoolingAsset3->transactionId,
                     'date' => $disposeOfSharePoolingAsset3->date,
                     'quantity' => $disposeOfSharePoolingAsset3->quantity,
-                    'costBasis' => FiatAmount::GBP('16'),
+                    'costBasis' => FiatAmount::GBP('25'),
                     'proceeds' => $disposeOfSharePoolingAsset3->proceeds,
                 ]),
         ),
         new SharePoolingAssetDisposedOf(
             disposal: SharePoolingAssetDisposal::factory()
                 ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+                ->make(['costBasis' => FiatAmount::GBP('30')]),
+        ),
+    );
+});
+
+it('can acquire a share pooling asset on the same day as other acquisitions and disposals and within 30 days of a disposal', function () {
+    given(new SharePoolingAssetFiatCurrencySet(FiatCurrency::GBP));
+
+    given(new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-10-21'),
+            quantity: new Quantity('100'),
+            costBasis: FiatAmount::GBP('100'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetDisposedOf1 = new SharePoolingAssetDisposedOf(
+        disposal: new SharePoolingAssetDisposal(
+            date: LocalDate::parse('2015-10-22'),
+            quantity: new Quantity('30'),
+            costBasis: FiatAmount::GBP('30'),
+            proceeds: FiatAmount::GBP('50'),
+            forFiat: false,
+        ),
+    ));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1->disposal));
+
+    given($sharePoolingAssetAcquired2 = new SharePoolingAssetAcquired(
+        acquisition: new SharePoolingAssetAcquisition(
+            date: LocalDate::parse('2015-10-23'),
+            quantity: new Quantity('20'),
+            costBasis: FiatAmount::GBP('40'),
+            forFiat: false,
+        ),
+    ));
+
+    given($sharePoolingAssetDisposedOf1Corrected1 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+            ->withThirtyDayQuantity(new Quantity('20'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('50')]),
+    ));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected1->disposal));
+
+    given($sharePoolingAssetDisposedOf2 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make([
+                'date' => LocalDate::parse('2015-10-23'),
+                'quantity' => new Quantity('10'),
+                'costBasis' => FiatAmount::GBP('20'),
+                'proceeds' => FiatAmount::GBP('30'),
+                'forFiat' => false,
+            ]),
+    ));
+
+    given($sharePoolingAssetDisposedOf1Corrected2 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+            ->withThirtyDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make(['costBasis' => FiatAmount::GBP('40')]),
+    ));
+
+    given(new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected2->disposal));
+
+    given($sharePoolingAssetDisposedOf3 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+            ->make([
+                'date' => LocalDate::parse('2015-10-23'),
+                'quantity' => new Quantity('15'),
+                'costBasis' => FiatAmount::GBP('25'),
+                'proceeds' => FiatAmount::GBP('40'),
+            ]),
+    ));
+
+    given($sharePoolingAssetDisposedOf1Corrected3 = new SharePoolingAssetDisposedOf(
+        disposal: SharePoolingAssetDisposal::factory()
+            ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+            ->make(['costBasis' => FiatAmount::GBP('30')]),
+    ));
+
+    when($acquireSharePoolingAsset3 = new AcquireSharePoolingAsset(
+        transactionId: SharePoolingAssetTransactionId::generate(),
+        asset: $this->aggregateRootId->toAsset(),
+        date: LocalDate::parse('2015-10-23'),
+        quantity: new Quantity('10'),
+        costBasis: FiatAmount::GBP('50'),
+        forFiat: false,
+    ));
+
+    then(
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf2->disposal),
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf3->disposal),
+        new SharePoolingAssetDisposalReverted(disposal: $sharePoolingAssetDisposedOf1Corrected3->disposal),
+        new SharePoolingAssetAcquired(
+            acquisition: new SharePoolingAssetAcquisition(
+                id: $acquireSharePoolingAsset3->transactionId,
+                date: $acquireSharePoolingAsset3->date,
+                quantity: $acquireSharePoolingAsset3->quantity,
+                costBasis: $acquireSharePoolingAsset3->costBasis,
+                forFiat: false,
+            ),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOf2->disposal)
+                ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+                ->make(['costBasis' => FiatAmount::GBP('30')]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->revert($sharePoolingAssetDisposedOf3->disposal)
+                ->withSameDayQuantity(new Quantity('10'), id: $sharePoolingAssetAcquired2->acquisition->id)
+                ->withSameDayQuantity(new Quantity('5'), id: $acquireSharePoolingAsset3->transactionId)
+                ->make(['costBasis' => FiatAmount::GBP('45')]),
+        ),
+        new SharePoolingAssetDisposedOf(
+            disposal: SharePoolingAssetDisposal::factory()
+                ->copyFrom($sharePoolingAssetDisposedOf1->disposal)
+                ->withThirtyDayQuantity(new Quantity('5'), id: $acquireSharePoolingAsset3->transactionId)
                 ->make(['costBasis' => FiatAmount::GBP('50')]),
         ),
     );

--- a/tests/Feature/Commands/ProcessTest.php
+++ b/tests/Feature/Commands/ProcessTest.php
@@ -28,9 +28,9 @@ it('can process a spreadsheet', function () {
         'tax_year_id' => '2020-2021',
         'currency' => FiatCurrency::GBP->value,
         'capital_gain' => json_encode([
-            'cost_basis' => '15709.51947887970615243342516069788787',
+            'cost_basis' => '16656.83425160697887970615243342516063',
             'proceeds' => '27979.5',
-            'difference' => '12269.98052112029384756657483930211213',
+            'difference' => '11322.66574839302112029384756657483937',
         ]),
         'income' => '1000',
         'non_attributable_allowable_cost' => '117',


### PR DESCRIPTION
## Summary

This PR revises the way same-day and 30-day quantities are allocated to acquisitions and refactors the `DisposalProcessor` and `ReversionFinder` services, as well as the `SharePoolingAsset` aggregate root.

## Explanation

### Quantity allocations

Since disposals are what's driving the allocation of same-day and 30-day quantities, these are now (de)allocated to/from the corresponding acquisitions upon applying `SharePoolingAssetDisposedOf` and `SharePoolingAssetDisposalReverted` events, and only then.

This means allocated quantities are now always correct, even upon replaying the events.

### `DisposalBuilder`

The `DisposalProcessor` service has now been renamed `DisposalBuilder`. Its only job is to return a `SharePoolingAssetDisposal` object with the right cost basis and quantity allocations. It now receives a copy of the aggregate's transactions, meaning it doesn't update the acquisitions it contains anymore.

That's now done upon applying the disposal events, as per the previous section.

### `SharePoolingAsset`

The aggregate root now only stores reverted disposals as unprocessed, as these need to keep their position in the array of transactions until they are replayed.

Be it an acquisition or a disposal, the concerned disposals are reverted first, then the acquisition or disposal is processed, then the reverted disposals are replayed.

This simplifies the logic within `DisposalBuilder` and `ReversionFinder`.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
