### PR TITLE
HMRC cryptoassets manual examples as tests

### DIFF
--- a/tests/Feature/Commands/ProcessTest.php
+++ b/tests/Feature/Commands/ProcessTest.php
@@ -45,3 +45,201 @@ it('can process a spreadsheet', function () {
         ->withArgs(fn (string $command, array $output) => $command === 'review')
         ->once();
 });
+
+it('matches HMRC cryptoassets manual example CRYPTO22251', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22251.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2023-2024',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '42000',
+            'proceeds' => '300000',
+            'difference' => '258000',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '174000',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});
+
+it('matches HMRC cryptoassets manual example CRYPTO22252', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22252.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2023-2024',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '937.5',
+            'proceeds' => '1400',
+            'difference' => '462.5',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '-100',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});
+
+it('matches HMRC cryptoassets manual example CRYPTO22253', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22253.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 2);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2022-2023',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '235',
+            'proceeds' => '400',
+            'difference' => '165',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2023-2024',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '130',
+            'proceeds' => '150',
+            'difference' => '20',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '-875',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});
+
+it('matches HMRC cryptoassets manual example CRYPTO22254', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22254.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2023-2024',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '67499.99999999999999999999999999998',
+            'proceeds' => '160000',
+            'difference' => '92500.00000000000000000000000000002',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '-57500',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});
+
+it('matches HMRC cryptoassets manual example CRYPTO22255', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22255.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2022-2023',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '562.499999999999999999999999999955',
+            'proceeds' => '642',
+            'difference' => '79.500000000000000000000000000045',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '-858',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});
+
+it('matches HMRC cryptoassets manual example CRYPTO22256', function () {
+    $this->instance(CommandRunnerContract::class, $commandRunner = Mockery::spy(CommandRunnerContract::class));
+
+    $path = base_path('tests/stubs/transactions/CRYPTO22256.csv');
+
+    $this->artisan('process', ['spreadsheet' => $path])->assertSuccessful();
+
+    $this->assertDatabaseCount('tax_year_summaries', 1);
+
+    $this->assertDatabaseHas('tax_year_summaries', [
+        'tax_year_id' => '2023-2024',
+        'currency' => FiatCurrency::GBP->value,
+        'capital_gain' => json_encode([
+            'cost_basis' => '538636.363636363636363636363636363',
+            'proceeds' => '400000',
+            'difference' => '-138636.363636363636363636363636363',
+        ]),
+        'income' => '0',
+        'non_attributable_allowable_cost' => '0',
+    ]);
+
+    $this->assertDatabaseHas('summaries', [
+        'currency' => FiatCurrency::GBP->value,
+        'fiat_balance' => '-170000',
+    ]);
+
+    $commandRunner->shouldHaveReceived('run')
+        ->withArgs(fn (string $command, array $output) => $command === 'review')
+        ->once();
+});

--- a/tests/stubs/transactions/CRYPTO22251.csv
+++ b/tests/stubs/transactions/CRYPTO22251.csv
@@ -1,0 +1,4 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,1000,GBP,1000,FALSE,BTC,100,FALSE,,,,FALSE
+18/09/2023,swap,125000,GBP,125000,FALSE,BTC,50,FALSE,,,,FALSE
+01/12/2023,swap,300000,BTC,50,FALSE,GBP,300000,FALSE,,,,FALSE

--- a/tests/stubs/transactions/CRYPTO22252.csv
+++ b/tests/stubs/transactions/CRYPTO22252.csv
@@ -1,0 +1,5 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,500,GBP,500,FALSE,BTC,5000,FALSE,,,,FALSE
+23/06/2023,swap,800,BTC,1000,FALSE,GBP,800,FALSE,,,,FALSE
+23/06/2023,swap,1000,GBP,1000,FALSE,BTC,1600,FALSE,,,,FALSE
+23/06/2023,swap,600,BTC,500,FALSE,GBP,600,FALSE,,,,FALSE

--- a/tests/stubs/transactions/CRYPTO22253.csv
+++ b/tests/stubs/transactions/CRYPTO22253.csv
@@ -1,0 +1,7 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,1000,GBP,1000,FALSE,BTC,2000,FALSE,,,,FALSE
+31/03/2023,swap,400,BTC,1000,FALSE,GBP,400,FALSE,,,,FALSE
+20/04/2023,swap,150,BTC,500,FALSE,GBP,150,FALSE,,,,FALSE
+21/04/2023,swap,175,GBP,175,FALSE,BTC,700,FALSE,,,,FALSE
+28/04/2023,swap,100,GBP,100,FALSE,BTC,500,FALSE,,,,FALSE
+01/05/2023,swap,150,GBP,150,FALSE,BTC,500,FALSE,,,,FALSE

--- a/tests/stubs/transactions/CRYPTO22254.csv
+++ b/tests/stubs/transactions/CRYPTO22254.csv
@@ -1,0 +1,4 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,200000,GBP,200000,FALSE,BTC,14000,FALSE,,,,FALSE
+30/08/2023,swap,160000,BTC,4000,FALSE,GBP,160000,FALSE,,,,FALSE
+11/09/2023,swap,17500,GBP,17500,FALSE,BTC,500,FALSE,,,,FALSE

--- a/tests/stubs/transactions/CRYPTO22255.csv
+++ b/tests/stubs/transactions/CRYPTO22255.csv
@@ -1,0 +1,8 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,1000,GBP,1000,FALSE,BTC,8000,FALSE,,,,FALSE
+31/01/2023,swap,500,BTC,5000,FALSE,GBP,500,FALSE,,,,FALSE
+31/01/2023,swap,320,GBP,320,FALSE,BTC,4000,FALSE,,,,FALSE
+31/01/2023,swap,75,GBP,75,FALSE,BTC,1000,FALSE,,,,FALSE
+31/01/2023,swap,70,GBP,70,FALSE,BTC,1000,FALSE,,,,FALSE
+31/01/2023,swap,142,BTC,2000,FALSE,GBP,142,FALSE,,,,FALSE
+31/01/2023,swap,35,GBP,35,FALSE,BTC,500,FALSE,,,,FALSE

--- a/tests/stubs/transactions/CRYPTO22256.csv
+++ b/tests/stubs/transactions/CRYPTO22256.csv
@@ -1,0 +1,7 @@
+Date,Operation,Market value,Sent asset,Sent quantity,Sent asset is non-fungible,Received asset,Received quantity,Received asset is non-fungible,Fee currency,Fee quantity,Fee market value,Income
+01/01/2023,swap,300000,GBP,300000,FALSE,BTC,100000,FALSE,,,,FALSE
+31/07/2023,swap,45000,GBP,45000,FALSE,BTC,10000,FALSE,,,,FALSE
+31/07/2023,swap,150000,BTC,30000,FALSE,GBP,150000,FALSE,,,,FALSE
+05/08/2023,swap,100000,BTC,20000,FALSE,GBP,100000,FALSE,,,,FALSE
+06/08/2023,swap,225000,GBP,225000,FALSE,BTC,50000,FALSE,,,,FALSE
+07/08/2023,swap,150000,BTC,100000,FALSE,GBP,150000,FALSE,,,,FALSE


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR adds tests covering the [example scenarios](https://www.gov.uk/hmrc-internal-manuals/cryptoassets-manual/crypto22250) laid out in HMRC's Cryptoassets manual.

## Explanation <!-- deeper explanation to guide reviewers -->

Each scenario has a dedicated CSV file listing transactions matching the examples.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
